### PR TITLE
Set "Queenstown International" as the airport name

### DIFF
--- a/data/airports.dat
+++ b/data/airports.dat
@@ -1987,7 +1987,7 @@
 2027,"Oamaru","Oamaru","New Zealand","OAM","NZOU",-44.97,171.081667,99,12,"Z","Pacific/Auckland"
 2028,"Palmerston North","Palmerston North","New Zealand","PMR","NZPM",-40.320556,175.616944,151,12,"Z","Pacific/Auckland"
 2029,"Paraparaumu","Paraparaumu","New Zealand","PPQ","NZPP",-40.904722,174.989167,22,12,"Z","Pacific/Auckland"
-2030,"Queenstown","Queenstown International","New Zealand","ZQN","NZQN",-45.021111,168.739167,1171,12,"Z","Pacific/Auckland"
+2030,"Queenstown International","Queenstown","New Zealand","ZQN","NZQN",-45.021111,168.739167,1171,12,"Z","Pacific/Auckland"
 2031,"Rotorua","Rotorua","New Zealand","ROT","NZRO",-38.109167,176.317222,935,12,"Z","Pacific/Auckland"
 2032,"Waiouru","Waiouru","New Zealand","","NZRU",-39.446389,175.658333,2686,12,"Z","Pacific/Auckland"
 2033,"South Pole Station","Stephen's Island","Antarctica","","NZSP",-89.999997,0,9300,12,"U","Antarctica/South_Pole"


### PR DESCRIPTION
Rather then the New Zealand city, which is simply "Queenstown".
