### PR TITLE
Update encoding information

### DIFF
--- a/data.html
+++ b/data.html
@@ -83,7 +83,7 @@
 	      </tr>
 	    </table>
 
-	    <p>The data is ISO 8859-1 (Latin-1) encoded, with no special characters.</p>
+	    <p>The data is UTF-8 encoded.</p>
 
 	    <p><i>Note</i>: Rules for daylight savings time change from year to year and from country to country.  The current data is an approximation for 2009, built on a country level.  Most airports in DST-less regions in countries that generally observe DST (eg. AL, HI in the USA, NT, QL in Australia, parts of Canada) are marked incorrectly.</p>
 
@@ -168,7 +168,7 @@
 		</tr>
 	    </table>
 
-	    <p>The data is ISO 8859-1 (Latin-1) encoded.  The special value <b>\N</b> is used for "NULL" to indicate that no value is available, and is understood automatically by MySQL if imported.</p>
+	    <p>The data is UTF-8 encoded.  The special value <b>\N</b> is used for "NULL" to indicate that no value is available, and is understood automatically by MySQL if imported.</p>
 	    <p><i>Notes</i>: Airlines with null codes/callsigns/countries generally represent user-added airlines.  Since the data is intended primarily for current flights, defunct IATA codes are generally not included.  For example, "Sabena" is not listed with a SN IATA code, since "SN" is presently used by its successor Brussels Airlines.</p>
 
 	    <h4>Sample entries</h4>
@@ -255,7 +255,7 @@
 		</tr>
 	    </table>
 
-	    <p>The data is ISO 8859-1 (Latin-1) encoded.  The special value <b>\N</b> is used for "NULL" to indicate that no value is available, and is understood automatically by MySQL if imported.</p>
+	    <p>The data is UTF-8 encoded, with no special characters.  The special value <b>\N</b> is used for "NULL" to indicate that no value is available, and is understood automatically by MySQL if imported.</p>
 
 	    <i>Notes</i>:
 	    <ul>


### PR DESCRIPTION
It seems the documentation on exports' encodings is outdated and all those files are now in UTF-8.  I took "with no special characters" to mean non-ASCII (which is only true for the routes data, and not airports/airlines.)
