### PR TITLE
airports: Doha Intl (OTBD) change to Hamad Intl (OTHH)

### DIFF
--- a/data/airports.dat
+++ b/data/airports.dat
@@ -2184,7 +2184,7 @@
 2237,"Deir Zzor","Deire Zor","Syria","DEZ","OSDZ",35.285374,40.175961,700,2,"E","Asia/Damascus"
 2239,"Bassel Al Assad Intl","Latakia","Syria","LTK","OSLK",35.401094,35.948681,157,2,"E","Asia/Damascus"
 2240,"Palmyra","Palmyra","Syria","PMS","OSPR",34.557361,38.316889,1322,2,"E","Asia/Damascus"
-2241,"Doha Intl","Doha","Qatar","DOH","OTBD",25.261125,51.565056,35,3,"U","Asia/Qatar"
+2241,"Hamad Intl","Doha","Qatar","DOH","OTHH",25.273056,51.608056,13,3,"U","Asia/Qatar"
 2242,"Canton","Canton Island","Kiribati","CIS","PCIS",-2.768122,-171.710394,9,13,"U","Pacific/Enderbury"
 2243,"Rota Intl","Rota","Northern Mariana Islands","ROP","PGRO",14.174308,145.242536,607,10,"U","Pacific/Saipan"
 2244,"Francisco C Ada Saipan Intl","Saipan","Northern Mariana Islands","SPN","PGSN",15.119003,145.729356,215,10,"U","Pacific/Saipan"


### PR DESCRIPTION
Since April 30th, 2014, the new Hamad Intl airport (OTHH) replaces the former
Doha Intl (OTBD). IATA code is kept to the old DOH.

https://en.wikipedia.org/wiki/Doha_International_Airport
https://en.wikipedia.org/wiki/Hamad_International_Airport
