### PR TITLE
airports: Mariscal Sucre Intl updated (SEQU->SEQM)

### DIFF
--- a/data/airports.dat
+++ b/data/airports.dat
@@ -2616,7 +2616,7 @@
 2685,"Amable Calle Gutierrez","Pasaje","Ecuador","","SEPS",-3.319667,-79.769165,22,-5,"U","America/Guayaquil"
 2686,"Reales Tamarindos","Portoviejo","Ecuador","PVO","SEPV",-1.041647,-80.472206,130,-5,"U","America/Guayaquil"
 2687,"Quevedo","Quevedo","Ecuador","","SEQE",-0.9894,-79.465114,350,-5,"U","America/Guayaquil"
-2688,"Mariscal Sucre Intl","Quito","Ecuador","UIO","SEQU",-0.141144,-78.488214,9228,-5,"U","America/Guayaquil"
+2688,"Mariscal Sucre Intl","Quito","Ecuador","UIO","SEQM",-0.1133,-78.3586,9228,-5,"U","America/Guayaquil"
 2689,"Chimborazo","Riobamba","Ecuador","","SERB",-1.653433,-78.656142,9151,-5,"U","America/Guayaquil"
 2690,"Coronel Artilleria Victor Larrea","Santa Rosa","Ecuador","","SERO",-3.435161,-79.977817,170,-5,"U","America/Guayaquil"
 2691,"General Ulpiano Paez","Salinas","Ecuador","SNC","SESA",-2.204994,-80.988878,18,-5,"U","America/Guayaquil"


### PR DESCRIPTION
Since February 19th 2013, the old Mariscal Sucre Intl airport (SEQU) has been
fully replaced by the new Mariscal Sucre Intl airport (SEQM). IATA code is kept
to the old UIO.

https://en.wikipedia.org/wiki/Mariscal_Sucre_International_Airport
https://en.wikipedia.org/wiki/Old_Mariscal_Sucre_International_Airport
