### PR TITLE
airports: set latitude/longitude for Enghien Moisselles (LFFE) airport

### DIFF
--- a/data/airports.dat
+++ b/data/airports.dat
@@ -4188,7 +4188,7 @@
 4300,"Chumphon","Chumphon","Thailand","CJM","VTSE",10.7112,99.361706,18,7,"U","Asia/Bangkok"
 4301,"Jiuzhaigou Huanglong","Jiuzhaigou","China","JZH","ZUJZ",32.857,103.683,11311,8,"U","Asia/Chongqing"
 4302,"Wai Sha Airport","Shantou","China","SWA","ZGOW",23.4,116.683,0,8,"U","Asia/Chongqing"
-4303,"Les Ailerons","Enghien-moisselles","France","","LFFE",0,0,302,0,"E",\N
+4303,"Les Ailerons","Enghien-moisselles","France","","LFFE",49.046398,2.353060,302,0,"E",\N
 4304,"Cheddi Jagan Intl","Georgetown","Guyana","GEO","SYCJ",6.498553,-58.254119,95,-4,"U","America/Guyana"
 4305,"Ciudad del Este","Ciudad del Este","Paraguay","AGT","SGES",-25.4555,-54.843592,846,-4,"S","America/Asuncion"
 4306,"Ogle","Georgetown","Guyana","OGL","SYGO",6.806944,-58.104444,10,-4,"U","America/Guyana"


### PR DESCRIPTION
http://airportguide.com/airport/France/%C3%8Ele-de-France/Guiscriff-LFFE/
