### PR TITLE
airports: renamed ICAO code for Lima airport from SPIM to SPJC

### DIFF
--- a/data/airports.dat
+++ b/data/airports.dat
@@ -2715,7 +2715,7 @@
 2786,"Coronel Fap Alfredo Mendivil Duarte","Ayacucho","Peru","AYP","SPHO",-13.154819,-74.204417,8917,-5,"U","America/Lima"
 2787,"Andahuaylas","Andahuaylas","Peru","ANS","SPHY",-13.706408,-73.350378,11300,-5,"U","America/Lima"
 2788,"Comandante Fap German Arias Graziani","Anta","Peru","ATA","SPHZ",-9.347444,-77.598392,9097,-5,"U","America/Lima"
-2789,"Jorge Chavez Intl","Lima","Peru","LIM","SPIM",-12.021889,-77.114319,113,-5,"U","America/Lima"
+2789,"Jorge Chavez Intl","Lima","Peru","LIM","SPJC",-12.021889,-77.114319,113,-5,"U","America/Lima"
 2790,"Juanjui","Juanjui","Peru","JJI","SPJI",-7.1691,-76.728561,1148,-5,"U","America/Lima"
 2791,"Francisco Carle","Jauja","Peru","","SPJJ",-11.783144,-75.473394,11034,-5,"U","America/Lima"
 2792,"Juliaca","Juliaca","Peru","JUL","SPJL",-15.467103,-70.158169,12552,-5,"U","America/Lima"


### PR DESCRIPTION
Since November 12th 2015, the Jorge Chávez International Airport uses the new
"SPJC" ICAO code, instead of the previous "SPIM".

https://en.wikipedia.org/wiki/Jorge_Ch%C3%A1vez_International_Airport
