### PR TITLE
Properly mark MOW as "All airports", to match other entries.

### DIFF
--- a/data/airports.dat
+++ b/data/airports.dat
@@ -6762,7 +6762,7 @@
 8190,"Superficie Cielo Blu","Vellezzo Bellini","Italy","",\N,45.283855,9.111979,350,1,"E","Europe/Rome"
 8191,"Welke Airport","Beaver Island","United States","6Y8",\N,45.721111,-85.520278,664,-5,"A","America/New_York"
 8192,"Krainiy","Baikonur","Kazakhstan","","UAOL",45.6183,63.2144,328,6,"U","Asia/Qyzylorda"
-8193,"MOW","Moscow","Russia","MOW",\N,55.7557,37.6176,0,4,"N","Europe/Moscow"
+8193,"All Airports","Moscow","Russia","MOW",\N,55.7557,37.6176,0,4,"N","Europe/Moscow"
 8194,"Westerly State Airport","Washington County","United States","WST","KWST",41.349722,-71.803333,81,-5,"A","America/New_York"
 8195,"Block Island State Airport","Block Island","United States","BID","KBID",41.168056,-71.577778,108,-5,"A","America/New_York"
 8196,"Atmautluak Airport","Atmautluak","United States","",\N,60.866667,-162.273056,18,-9,"A","America/Anchorage"


### PR DESCRIPTION
I believe this is a good fix for airports.dat.
