### PR TITLE
code update for Magas, Nazran

### DIFF
--- a/data/airports.dat
+++ b/data/airports.dat
@@ -5328,7 +5328,7 @@
 6456,"Provincetown Muni","Provincetown","United States","PVC","KPVC",42.071945,-70.22139,9,-5,"A","America/New_York"
 6457,"Kenmore Air Harbor Seaplane Base","Seattle","United States","LKE","KW55",47.629,-122.339,14,-8,"A","America/Los_Angeles"
 6458,"Seria - Anduki","Seria","Brunei","","WBAK",4.6333,114.3833,5,8,"N","Asia/Brunei"
-6459,"Magas","Nazran","Russia","%u0","%u04",43.323815,45.017761,1060,4,"N","Europe/Moscow"
+6459,"Magas","Nazran","Russia","IGT","URMS",43.323815,45.017761,1060,4,"N","Europe/Moscow"
 6460,"Saint Barthelemy","Gustavia","France","SBH","TFFJ",17.9023,-62.8324,50,-4,"E",\N
 6461,"Morro de Sao Paulo","Morro de Sao Paulo","Brazil","",\N,-13.2314,-38.5432,10,3,"S",\N
 6462,"Morro de Sao Paulo","Morro de Sao Paulo","Brazil","",\N,-13.386571,-38.909122,10,-3,"S","America/Fortaleza"


### PR DESCRIPTION
I fixed the IATA and ICAO airport codes for Magas based on information on [AirportCodes](http://www.airportcodes.aero/airport-code-urms). I also check other sources like [IATA](http://www.iata.org/publications/Pages/code-search.aspx) and [airlinecodes.co.uk](http://www.airlinecodes.co.uk/aptcodesearch.asp) to confirm this.
