### PR TITLE
Fixed name of the Vadsø Airport

### DIFF
--- a/data/airports.dat
+++ b/data/airports.dat
@@ -4213,7 +4213,7 @@
 4325,"Hammerfest Airport","Hammerfest","Norway","HFT","ENHF",70.679722,23.668889,799,1,"E","Europe/Oslo"
 4326,"Valan","Honningsvag","Norway","HVG","ENHV",70.99,25.83,46,1,"E","Europe/Oslo"
 4327,"Mehamn","Mehamn","Norway","MEH","ENMR",71.029722,27.826667,41,1,"E","Europe/Oslo"
-4328,"Vadsø Airport","Vadso","Norway","VDS","ENVD",70.065,29.844,127,1,"E","Europe/Oslo"
+4328,"Vadsø Airport","Vadsø","Norway","VDS","ENVD",70.065,29.844,127,1,"E","Europe/Oslo"
 4329,"Riem","Munich","Germany","","MUCX",48.137778,11.690278,1487,1,"E","Europe/Berlin"
 4330,"Imam Khomeini","Tehran","Iran","IKA","OIIE",35.416111,51.152222,3305,3.5,"E","Asia/Tehran"
 4331,"Mashhad","Mashhad","Iran","MHD","OIMM",36.234,59.643,3263,3.5,"E","Asia/Tehran"

--- a/data/airports.dat
+++ b/data/airports.dat
@@ -4213,7 +4213,7 @@
 4325,"Hammerfest Airport","Hammerfest","Norway","HFT","ENHF",70.679722,23.668889,799,1,"E","Europe/Oslo"
 4326,"Valan","Honningsvag","Norway","HVG","ENHV",70.99,25.83,46,1,"E","Europe/Oslo"
 4327,"Mehamn","Mehamn","Norway","MEH","ENMR",71.029722,27.826667,41,1,"E","Europe/Oslo"
-4328,"Airport","Vadso","Norway","VDS","ENVD",70.065,29.844,127,1,"E","Europe/Oslo"
+4328,"Vadsø Airport","Vadso","Norway","VDS","ENVD",70.065,29.844,127,1,"E","Europe/Oslo"
 4329,"Riem","Munich","Germany","","MUCX",48.137778,11.690278,1487,1,"E","Europe/Berlin"
 4330,"Imam Khomeini","Tehran","Iran","IKA","OIIE",35.416111,51.152222,3305,3.5,"E","Asia/Tehran"
 4331,"Mashhad","Mashhad","Iran","MHD","OIMM",36.234,59.643,3263,3.5,"E","Asia/Tehran"


### PR DESCRIPTION
Fixed the entry for the Vadsø Airport in `airports.dat`.
