### PR TITLE
:art: Correct the name based on the name from its official website

### DIFF
--- a/data/airports.dat
+++ b/data/airports.dat
@@ -1297,7 +1297,7 @@
 1332,"Chambéry-Challes-les-Eaux Airport","Chambery","France",\N,"LFLE",45.5611000061,5.975759983060001,973,1,"E","Europe/Paris","airport","OurAirports"
 1333,"Chalon-Champforgeuil Airport","Chalon","France","XCD","LFLH",46.82609939575195,4.817629814147949,623,1,"E","Europe/Paris","airport","OurAirports"
 1334,"Annemasse Airport","Annemasse","France","QNJ","LFLI",46.1920013428,6.268390178680001,1620,1,"E","Europe/Paris","airport","OurAirports"
-1335,"Lyon Saint-Exupéry Airport","Lyon","France","LYS","LFLL",45.7255556,5.0811111,821,1,"E","Europe/Paris","airport","OurAirports"
+1335,"Lyon-Saint Exupéry Airport","Lyon","France","LYS","LFLL",45.7255556,5.0811111,821,1,"E","Europe/Paris","airport","OurAirports"
 1336,"Mâcon-Charnay Airport","Macon","France","QNX","LFLM",46.295101,4.79577,728,1,"E","Europe/Paris","airport","OurAirports"
 1337,"Saint-Yan Airport","St.-yan","France",\N,"LFLN",46.412498474121094,4.0132598876953125,796,1,"E","Europe/Paris","airport","OurAirports"
 1338,"Roanne-Renaison Airport","Roanne","France","RNE","LFLO",46.05830001831055,4.001389980316162,1106,1,"E","Europe/Paris","airport","OurAirports"


### PR DESCRIPTION
According to its official [website](https://www.lyonaeroports.com/) and tons of researches, I'd like to submit this PR for the name change from `Lyon Saint-Exupéry` to `Lyon-Saint Exupéry`.

Fixes #703

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jpatokal/openflights/702)
<!-- Reviewable:end -->
