### PR TITLE
Updated Alaska Airlines callsign and country value

### DIFF
--- a/data/airlines.dat
+++ b/data/airlines.dat
@@ -437,7 +437,7 @@
 436,"Aero Transportes Del Humaya",\N,"","HUY","AERO HUMAYA","Mexico","N"
 437,"Argosy Airways",\N,"","ARY","GOSEY","United States","N"
 438,"Air Resorts",\N,"","ARZ","AIR RESORTS","United States","N"
-439,"Alaska Airlines",\N,"AS","ASA"," Inc.","ALASKA","Y"
+439,"Alaska Airlines",\N,"AS","ASA","ALASKA","United States","Y"
 440,"Air-Spray 1967 Ltd.",\N,"","ASB","AIR SPRAY","Canada","N"
 441,"Air Star Corporation",\N,"","ASC","AIR STAR","Canada","N"
 442,"Air Sinai",\N,"4D","ASD","AIR SINAI","Egypt","Y"


### PR DESCRIPTION
Entry 439, Alaska Airlines, Changed:
`callsign`: " Inc." -> "ALASKA"
`country`: "ALASKA" -> "United States"

I found the problem while pulling airline data from https://openflights.org/html/alsearch