### PR TITLE
Corrected IATA Code for airport NQZ

### DIFF
--- a/data/airports.dat
+++ b/data/airports.dat
@@ -2761,7 +2761,7 @@
 2907,"Argyle International Airport","Kingstown","Saint Vincent and the Grenadines","SVD","TVSA",13.156695,-61.149945,136,-4,"U","America/St_Vincent","airport","OurAirports"
 2908,"Almaty Airport","Alma-ata","Kazakhstan","ALA","UAAA",43.35210037231445,77.04049682617188,2234,6,"U","Asia/Qyzylorda","airport","OurAirports"
 2909,"Balkhash Airport","Balkhash","Kazakhstan","BXH","UAAH",46.8932991027832,75.00499725341797,1446,6,"U","Asia/Qyzylorda","airport","OurAirports"
-2910,"Astana International Airport","Tselinograd","Kazakhstan","TSE","UACC",51.02220153808594,71.46690368652344,1165,6,"U","Asia/Qyzylorda","airport","OurAirports"
+2910,"Nursultan Nazarbayev International Airport","Tselinograd","Kazakhstan","NQZ","UACC",51.02220153808594,71.46690368652344,1165,6,"U","Asia/Qyzylorda","airport","OurAirports"
 2911,"Taraz Airport","Dzhambul","Kazakhstan","DMB","UADD",42.853599548339844,71.30359649658203,2184,6,"U","Asia/Qyzylorda","airport","OurAirports"
 2912,"Manas International Airport","Bishkek","Kyrgyzstan","FRU","UAFM",43.0612983704,74.4776000977,2058,6,"U","Asia/Bishkek","airport","OurAirports"
 2913,"Osh Airport","Osh","Kyrgyzstan","OSS","UAFO",40.6090011597,72.793296814,2927,6,"U","Asia/Bishkek","airport","OurAirports"


### PR DESCRIPTION
Corrected IATA Code for airport NQZ.  It was TSE in the past but was changed when the city's name was changed.