### PR TITLE
phpQuery-onefile: Replace removed split()

### DIFF
--- a/php/phpQuery-onefile.php
+++ b/php/phpQuery-onefile.php
@@ -4206,7 +4206,7 @@ class phpQueryObject
 					.($node->getAttribute('id')
 						? '#'.$node->getAttribute('id'):'')
 					.($node->getAttribute('class')
-						? '.'.join('.', split(' ', $node->getAttribute('class'))):'')
+						? '.'.join('.', preg_split(' ', $node->getAttribute('class'))):'')
 					.($node->getAttribute('name')
 						? '[name="'.$node->getAttribute('name').'"]':'')
 					.($node->getAttribute('value') && strpos($node->getAttribute('value'), '<'.'?php') === false


### PR DESCRIPTION
Removed in PHP 7