### PR TITLE
Addressing many PHP 8 warnings

### DIFF
--- a/badge/banner.php
+++ b/badge/banner.php
@@ -66,9 +66,13 @@ if ($row["public"] == "N") {
 $uid = $row["uid"];
 $units = $row["units"];
 
-$sth = $dbh->prepare(
-    "SELECT COUNT(*) AS count, SUM(distance) AS distance, SUM(TIME_TO_SEC(duration))/60 AS duration FROM flights WHERE uid=?"
-);
+$sth = $dbh->prepare(<<<SQL
+SELECT COUNT(*) AS count,
+       COALESCE(SUM(distance), 0) AS distance,
+       COALESCE(SUM(TIME_TO_SEC(duration))/60, 0) AS duration
+FROM flights
+WHERE uid=?
+SQL);
 $result = $sth->execute([$uid]);
 if ($result && $row = $sth->fetch()) {
     $distance = $row["distance"];
@@ -83,7 +87,7 @@ if ($result && $row = $sth->fetch()) {
     $duration = sprintf(
         "%d days, %d:%02d hours",
         $row["duration"] / 1440,
-        ($row["duration"] / 60) % 24,
+        intdiv($row["duration"], 60) % 24,
         $row["duration"] % 60
     );
 } else {

--- a/php/flights.php
+++ b/php/flights.php
@@ -21,15 +21,12 @@ if ($export) {
 } else {
     header("Content-type: text/html; charset=utf-8");
 
-    $apid = $_POST["id"];
-    if (!$apid) {
-        $apid = $_GET["id"];
-    }
-    $trid = $_POST["trid"];
-    $alid = $_POST["alid"];
-    $fid = $_POST["fid"];
-    $user = $_POST["user"];
-    $year = $_POST["year"];
+    $apid = $_POST["id"] ?? ($_GET["id"] ?? "");
+    $trid = $_POST["trid"] ?? null;
+    $alid = $_POST["alid"] ?? null;
+    $user = $_POST["user"] ?? null;
+    $year = $_POST["year"] ?? null;
+    $fid = $_POST["fid"] ?? null;
 }
 
 include 'helper.php';

--- a/php/import.php
+++ b/php/import.php
@@ -1,7 +1,5 @@
 <?php
 
-ini_set('auto_detect_line_endings', true);
-
 require_once("locale.php");
 require_once("db_pdo.php");
 ?>
@@ -29,9 +27,9 @@ if (!$uid || empty($uid)) {
 require_once '../vendor/autoload.php';
 include_once('helper.php');
 
-$posMap = array("Window" => "W", "Middle" => "M", "Aisle" => "A");
-$classMap = array("Economy" => "Y", "Prem.Eco" => "P", "Business" => "C", "First" => "F");
-$reasonMap = array("Business" => "B", "Personal" => "L", "Crew" => "C", "Other" => "O");
+$posMap = array("Window" => "W", "Middle" => "M", "Aisle" => "A", "" => "");
+$classMap = array("Economy" => "Y", "Prem.Eco" => "P", "Business" => "C", "First" => "F", "" => "");
+$reasonMap = array("Business" => "B", "Personal" => "L", "Crew" => "C", "Other" => "O", "" => "");
 
 function nth_text($element, $n) {
     $xpath = new DOMXPath($element->ownerDocument);
@@ -329,7 +327,7 @@ switch ($action) {
 }
 
 $fileType = $_POST["fileType"];
-$history = $_POST["historyMode"];
+$history = $_POST["historyMode"] ?? null;
 $status = "";
 $id_note = false;
 
@@ -470,10 +468,7 @@ foreach ($rows as $row) {
 
             $datetime = explode(' ', $row[0]);
             list($src_date, $date_bgcolor) = check_date($dbh, $fileType, $datetime[0]);
-            $src_time = $datetime[1];
-            if (!$src_time) {
-                $src_time = "";
-            }
+            $src_time = $datetime[1] ?? "";
 
             $src_iata = $row[1];
             $src_apid = $row[15];
@@ -521,6 +516,7 @@ foreach ($rows as $row) {
             if ($row[9] == "B") {
                 $seatclass = "Business";
             } // fix for typo in pre-0.3 versions of spec
+            $seattype = ""; // This field is not present in CSVs
             $seatreason = array_search($row[10], $reasonMap);
             $reg = $row[12];
             list($trid, $trip_bgcolor) = check_trip($dbh, $uid, $row[13]);
@@ -647,7 +643,8 @@ foreach ($rows as $row) {
                 $reg,
                 $number,
                 $seatnumber,
-                substr($seatpos, 0, 1), $classMap[$seatclass],
+                substr($seatpos, 0, 1),
+                $classMap[$seatclass],
                 $reasonMap[$seatreason],
                 $comment,
                 $plid ? $plid : null,

--- a/php/map.php
+++ b/php/map.php
@@ -132,7 +132,7 @@ if ($row = $sth->fetch()) {
     if (!$distance) {
         $distance = "0";
     }
-    if ($_SESSION["units"] == "K") {
+    if ($_SESSION["units"] ?? null == "K") {
         $distance = round($distance * KM_PER_MILE) . " " . _("km");
     } else {
         $distance = $distance . " " . _("miles");

--- a/php/settings.php
+++ b/php/settings.php
@@ -4,16 +4,16 @@ include 'locale.php';
 include 'db_pdo.php';
 
 $type = $_POST["type"];
-$name = $_POST["name"];
+$name = $_POST["name"] ?? null;
 $pw = $_POST["pw"];
-$oldpw = $_POST["oldpw"];
-$oldlpw = $_POST["oldlpw"];
+$oldpw = $_POST["oldpw"] ?? null;
+$oldlpw = $_POST["oldlpw"] ?? null;
 $email = $_POST["email"];
 $privacy = $_POST["privacy"];
 $editor = $_POST["editor"];
 $units = $_POST["units"];
-$guestpw = $_POST["guestpw"];
-$startpane = $_POST["startpane"];
+$guestpw = $_POST["guestpw"] ?? null;
+$startpane = $_POST["startpane"] ?? null;
 $locale = $_POST["locale"]; // override any value in URL/session
 
 // 0 error

--- a/php/stats.php
+++ b/php/stats.php
@@ -5,19 +5,13 @@ include 'db_pdo.php';
 include 'helper.php';
 include 'filter.php';
 
-$uid = $_SESSION["uid"];
 $public = "O"; // by default...
-if (!$uid || empty($uid)) {
-    // If not logged in, default to demo mode
-    $uid = 1;
-}
 
-// This applies only when viewing another users flights
-$user = $_POST["user"];
-if (!$user) {
-    $user = $_GET["user"];
-}
-$trid = $_POST["trid"];
+// If not logged in, default to demo mode
+$uid = $_SESSION["uid"] ?? 1;
+
+$user = $_POST["user"] ?? ($_GET["user"] ?? null);
+$trid = $_POST["trid"] ?? null;
 
 // Verify that this trip and user are public
 $filter = "";
@@ -58,7 +52,7 @@ $filter = "f.uid=" . $uid . getFilterString($dbh, $_POST);
 $array = array();
 
 // Convert mi to km if units=K
-$units = $_SESSION["units"];
+$units = $_SESSION["units"] ?? null;
 if ($units == "K") {
     $unit = _("km");
     $multiplier = "* " . KM_PER_MILE;

--- a/php/top10.php
+++ b/php/top10.php
@@ -5,17 +5,15 @@ include 'db_pdo.php';
 include 'helper.php';
 include 'filter.php';
 
-$uid = $_SESSION["uid"];
-if (!$uid || empty($uid)) {
-    // If not logged in, default to demo mode
-    $uid = 1;
-}
-// This applies only when viewing another users flights
-$user = $_POST["user"];
-$trid = $_POST["trid"];
-$units = $_SESSION["units"];
+// If not logged in, default to demo mode
+$uid = $_SESSION["uid"] ?? 1;
+$units = $_SESSION["units"] ?? null;
 
-$mode = $_POST["mode"];
+// This applies only when viewing another users flights
+$user = $_POST["user"] ?? null;
+$trid = $_POST["trid"] ?? null;
+
+$mode = $_POST["mode"] ?? null;
 switch ($mode) {
     case "D":
         $mode = "SUM(distance)";
@@ -29,10 +27,8 @@ switch ($mode) {
         $mode = "COUNT(fid)";
         break;
 }
-$limit = $_POST["limit"];
-if (!$limit) {
-    $limit = "10";
-}
+
+$limit = $_POST["limit"] ?? "10";
 if ($limit == "-1") {
     $limit = "9999";
 }


### PR DESCRIPTION
- Added the null coalescing operator (`??`) in tons of places to avoid warnings (notices before version 8) about undefined array keys. The most common use cases are reading optional request parameters or handling multiple different request types in the same place.
- `auto_detect_line_endings` is [deprecated in PHP 8](https://php.watch/versions/8.1/auto_detect_line_endings-ini-deprecated) and redundant.
- MySQL returns `null` for SUM on zero rows. Used `COALESCE` to get 0 instead for use in calculations. (scenario: User settings page for a user without any flights - e.g. a new user)
- Used `intdiv` to avoid "PHP deprecated: Implicit conversion from float ... to int loses precision" when calculation the total flight duration in days/hours/minutes for the banner.
- The `seattype` field is not defined while processing CSV imports. I set the value to `""` to avoid an undefined variable warning when the variable is used to present the user with the data read out of the file. Side note: I don't believe this field is actually used.
- Added `"" => ""` mappings in `import.php`'s' class/reason/pos lookup tables to avoid undefined array key warnings for cases.