### PR TITLE
Links to follow host protocol

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -180,8 +180,8 @@ function signup(str) {
 
 function changeName() {
   var name = document.forms['signupform'].username.value;
-  var url = "https://" + location.host + "/user/" + encodeURIComponent(name);
-  $('profileurl').innerHTML = gt.gettext("Profile address:") + url;
+  var url = location.origin + "/user/" + encodeURIComponent(name);
+  $('profileurl').innerHTML = gt.gettext("Profile address: ") + url;
 }
 
 // Swap privacy panes
@@ -218,5 +218,5 @@ function showError(err) {
 // Need to duplicate this from openflights.js so that it opens in Settings window, not main, and
 // IE does not go nuts
 function backupFlights() {
-  location.href="https://" + location.host + "/php/flights.php?export=backup";
+  location.href = location.origin + "/php/flights.php?export=backup";
 }

--- a/openflights.js
+++ b/openflights.js
@@ -1521,9 +1521,9 @@ function listFlights(str, desc, id) {
 // newWindow: true if we want target URL to open in a new window.
 function exportFlights(type, newWindow) {
   if(type == "KML") {
-    url = "https://" + location.host + "/php/kml.php?" + lastQuery;
+    url = location.origin + "/php/kml.php?" + lastQuery;
   } else {
-    url = "https://" + location.host + "/php/flights.php?" + lastQuery + "&export=" + type;
+    url = location.origin + "/php/flights.php?" + lastQuery + "&export=" + type;
   }
   if(newWindow) {
     window.open(url, "openflights_export");
@@ -2962,7 +2962,7 @@ function login(str, param) {
   case 2:
     // Successful but need to switch UI language, so reload, stripping out any "?lang" in the URL
     $("loginstatus").innerHTML = "<B>" + gt.gettext("Loading") + "</B>";
-    location.href = "https://" + location.host + location.pathname;
+    location.href = location.origin + location.pathname;
     break;
 
   default:


### PR DESCRIPTION
This came up as part of my [Docker setup testing](https://github.com/jpatokal/openflights/pull/1206#issuecomment-1597306223) where I don't have `https` set up. I think it makes sense to follow whichever origin (protocol, host, and port) was used to reach the page in the first place. The code already uses `location.host` and gets the port instead of hardcoding 443.

MDN shows this feature is widely supported by browsers: https://developer.mozilla.org/en-US/docs/Web/API/Location/origin

The real `nginx` file redirects all requests to HTTPS so this change does not affect any real traffic.

When testing with my `http` setup this fixes:

- flight list export buttons (CSV and KML)
- settings page backup button
- sign-up page new profile URL (display only, it's not a link since the profile doesn't exist yet)

I haven't been able to reproduce the `case 2:` behavior from the [login function](https://github.com/jpatokal/openflights/blob/master/openflights.js#L2962). I believe this is meant to reset the language from whatever was set prior to login to the user's settings-defined language. Still, it does not work the way I described it above on `openflights.org` either.