### PR TITLE
SQL updates for the `planes` table

### DIFF
--- a/sql/clean-duplicate-planes.sql
+++ b/sql/clean-duplicate-planes.sql
@@ -7,7 +7,7 @@ select name, min(plid), max(plid), count(*) as dupes from planes GROUP BY name h
 
 -- Find exact dupes
 drop table if exists tmp_planes_duplicates;
-create table tmp_planes_duplicates (plid int, duplicate_of int)
+create table tmp_planes_duplicates (plid int, duplicate_of int);
 insert into tmp_planes_duplicates
     select p1.plid, min(p2.plid) as duplicate_of
     from planes p1, planes p2

--- a/sql/create.sql
+++ b/sql/create.sql
@@ -1,5 +1,7 @@
+DROP DATABASE IF EXISTS flightdb2;
 CREATE DATABASE flightdb2;
 
+DROP USER IF EXISTS openflights@localhost;
 CREATE USER openflights@localhost;
 GRANT ALL PRIVILEGES ON flightdb2.* TO openflights@localhost;
 
@@ -155,12 +157,16 @@ CREATE TABLE `locales` (
 
 DROP TABLE IF EXISTS `planes`;
 CREATE TABLE `planes` (
-  `name` text,
+  `name` varchar(80),
   `abbr` text,
   `speed` double default NULL,
   `plid` int(11) NOT NULL auto_increment,
   `public` char(1) default NULL,
-  PRIMARY KEY  (`plid`)
+  `iata` text default NULL,
+  `icao` text default NULL,
+  `frequency` int default 0,
+  PRIMARY KEY  (`plid`),
+  UNIQUE KEY `name` (`name`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 DROP TABLE IF EXISTS `routes`;

--- a/sql/create.sql
+++ b/sql/create.sql
@@ -161,10 +161,10 @@ CREATE TABLE `planes` (
   `abbr` text,
   `speed` double default NULL,
   `plid` int(11) NOT NULL auto_increment,
-  `public` char(1) default NULL,
+  `public` char(1) default 'N',
   `iata` text default NULL,
   `icao` text default NULL,
-  `frequency` int default 0,
+  `frequency` int(11) default 0,
   PRIMARY KEY  (`plid`),
   UNIQUE KEY `name` (`name`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;

--- a/sql/create.sql
+++ b/sql/create.sql
@@ -1,7 +1,5 @@
-DROP DATABASE IF EXISTS flightdb2;
 CREATE DATABASE flightdb2;
 
-DROP USER IF EXISTS openflights@localhost;
 CREATE USER openflights@localhost;
 GRANT ALL PRIVILEGES ON flightdb2.* TO openflights@localhost;
 

--- a/sql/load-data.sql
+++ b/sql/load-data.sql
@@ -34,6 +34,14 @@ OPTIONALLY ENCLOSED BY '"'
 LINES TERMINATED BY '\n'
 (name, iso_code, dafif_code);
 
+\! echo Importing planes...
+LOAD DATA LOCAL INFILE 'data/planes.dat'
+REPLACE INTO TABLE planes
+FIELDS TERMINATED BY ','
+OPTIONALLY ENCLOSED BY '"'
+LINES TERMINATED BY '\n'
+(name, iata, icao);
+
 \! echo Importing locales...
 
 LOAD DATA LOCAL INFILE 'locale/locales.dat'


### PR DESCRIPTION
This updates `create.sql` with the schema changes that were brought in through `clean-duplicate-planes.sql` in https://github.com/jpatokal/openflights/commit/36b3ee9d5c087e38f9011c9c338a37f7ddb06ee2.

Additionally, this updates `load-data.sql` to seed the DB with the data present in `data/planes.dat`.

Resolves #1210.