### PR TITLE
Improved Banner Thousands Separator Logic

### DIFF
--- a/badge/banner.php
+++ b/badge/banner.php
@@ -79,7 +79,7 @@ if ($result && $row = $sth->fetch()) {
         $units = "miles";
     }
     $flights = sprintf("%s flights", $row["count"]);
-    $miles = sprintf("%d,%03d %s", $distance / 1000, $distance % 1000, $units);
+    $miles = sprintf("%s %s", number_format($distance, 0, ".", ","), $units);
     $duration = sprintf(
         "%d days, %d:%02d hours",
         $row["duration"] / 1440,


### PR DESCRIPTION
Use `number_format` to generalize inserting the thousands separators. This fixes formatting for distances over 1 million.

Tested numbers up to 1 billion.

| Old format   | New format     |
|--------------|----------------|
|            1 |              1 |
|        1,000 |          1,000 |
|     1000,000 |      1,000,000 |
|  1000000,000 |  1,000,000,000 |

Fixes #153.

Side notes:

1. We specify "," because the banner is in English. We could load the user's locale and use that but that would only make sense if we internationalized the whole banner.
2. The web UI doesn't have any thousands separator at all. Easy enough to add but ought to be done in a separate PR.