### PR TITLE
Fix Artistic Layer Functionality

### DIFF
--- a/openflights.js
+++ b/openflights.js
@@ -137,7 +137,7 @@ var poliLayer = new OpenLayers.Layer.XYZ(
 var artLayer = new OpenLayers.Layer.XYZ(
     "Artistic",
     [
-        "https://stamen-tiles.a.ssl.fastly.net/watercolor/${z}/${x}/${y}.png"
+        "https://stamen-tiles.a.ssl.fastly.net/watercolor/${z}/${x}/${y}.jpg"
     ], {
         attribution: "Map tiles &copy; <a href='http://maps.stamen.com/' target='_blank'>Stamen</a> (CC BY 3.0), data &copy; <a href='https://www.openstreetmap.org' target='_blank'>OSM</a> (CC BY SA)",
         sphericalMercator: true,


### PR DESCRIPTION
The artistic layer (upper right hand side globe button -> artistic) seems to be broken on https://openflights.org today. The map does not load any tiles.

In the debug console, I'm seeing all tile requests return 404s (they first get 302'd to https://tiles.stadiamaps.com).

[The docs for the Watercolor tiles](http://maps.stamen.com/#watercolor) we're using for this specify `.jpg` (instead of `.png`) as the extension in the URL template.

I checked Internet Archive snapshots and the `jpg` extension has been there [since 2015](https://archive.is/hFtwi). My theory is that they used to serve `png` as well but perhaps they stopped when they set up the redirects to stadiamaps.com.