### PR TITLE
Include git commit hash in HTML metadata

### DIFF
--- a/about.php
+++ b/about.php
@@ -1,7 +1,12 @@
+<?php
+require_once "php/git.php";
+?>
+
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html>
 <head>
     <title>OpenFlights: About</title>
+    <meta name="version" content="<?php echo Git::getCurrentCommitID() ?? "unavailable"; ?>">
     <link rel="stylesheet" href="/css/style_reset.css" type="text/css">
     <link rel="stylesheet" href="/openflights.css" type="text/css">
     <link rel="icon" type="image/png" href="/img/icon_favicon.png"/>

--- a/data.html
+++ b/data.html
@@ -147,7 +147,7 @@
             </tr>
         </table>
 
-        <p>The GitHub copy is only a sporadically updated static snapshot of the live OpenFlights database (see <a href="https://github.com/jpatokal/openflights/commits/master/data/airports.dat">revision log</a>). If you would like an up-to-the-minute copy, or you would like your data filtered by any information available to us (eg. number of routes at the airport), do not hesitate to <a href="/about.html">contact us</a>.<p>
+        <p>The GitHub copy is only a sporadically updated static snapshot of the live OpenFlights database (see <a href="https://github.com/jpatokal/openflights/commits/master/data/airports.dat">revision log</a>). If you would like an up-to-the-minute copy, or you would like your data filtered by any information available to us (eg. number of routes at the airport), do not hesitate to <a href="/about">contact us</a>.<p>
 
         <p>If you'd like an even more thorough database, with extensive coverage of airstrips, heliports and other places of less interest for commercial airline frequent flyers, do check out <a href="https://ourairports.com">OurAirports</a>, whose public domain database covers over 40,000 places to fly from.<p>
 
@@ -243,7 +243,7 @@
             </tr>
         </table>
 
-        <p>The GitHub copy is only a sporadically updated static snapshot of the live OpenFlights database (see <a href="https://github.com/jpatokal/openflights/commits/master/data/airlines.dat">revision log</a>). If you would like an up-to-the-minute copy, or you would like your data filtered by any information available to us (eg. number of flights by airline), do not hesitate to <a href="/about.html">contact us</a>.<p>
+        <p>The GitHub copy is only a sporadically updated static snapshot of the live OpenFlights database (see <a href="https://github.com/jpatokal/openflights/commits/master/data/airlines.dat">revision log</a>). If you would like an up-to-the-minute copy, or you would like your data filtered by any information available to us (eg. number of flights by airline), do not hesitate to <a href="/about">contact us</a>.<p>
 
         <a name="route"></a>
         <h2>Route database</h2>
@@ -353,7 +353,7 @@ TOM,5013,ACE,1055,BFS,465,,0,320
             </tr>
         </table>
 
-        <p>The GitHub copy is only a sporadically updated static snapshot of the live OpenFlights database (see <a href="https://github.com/jpatokal/openflights/commits/master/data/routes.dat">revision log</a>). If you would like an up-to-the-minute copy, or you would like your data filtered by any information available to us (eg. number of routes by airline), do not hesitate to <a href="/about.html">contact us</a>.<p>
+        <p>The GitHub copy is only a sporadically updated static snapshot of the live OpenFlights database (see <a href="https://github.com/jpatokal/openflights/commits/master/data/routes.dat">revision log</a>). If you would like an up-to-the-minute copy, or you would like your data filtered by any information available to us (eg. number of routes by airline), do not hesitate to <a href="/about">contact us</a>.<p>
 
         <a name="plane"></a>
         <h2>Plane database</h2>

--- a/openflights.js
+++ b/openflights.js
@@ -431,7 +431,7 @@ function drawAirport(airportLayer, apdata, name, city, country, count, formatted
   // This should never happen
   if(! airportIcons[colorIndex]) {
     $("news").style.display = 'inline';
-    $("news").innerHTML = "ERROR: " + name + ":" + colorIndex + " of " + airportMaxFlights + ".i<br>Please hit CTRL-F5 to force refresh, and <a href='/about.html'>report</a> this error if it does not go away.";
+    $("news").innerHTML = "ERROR: " + name + ":" + colorIndex + " of " + airportMaxFlights + ".i<br>Please hit CTRL-F5 to force refresh, and <a href='/about'>report</a> this error if it does not go away.";
     colorIndex = 0;
     return;
   }

--- a/php/git.php
+++ b/php/git.php
@@ -1,0 +1,19 @@
+<?php
+
+class Git {
+
+    /**
+     * Retrieve the commit ID of the current HEAD.
+     * @return string|null commit ID or null on failure
+     */
+    public static function getCurrentCommitID() {
+        $head = file_get_contents(".git/HEAD");
+
+        $matches = [];
+        if (preg_match("/ref: (.*)/", $head, $matches)) {
+            $head = file_get_contents(".git/{$matches[1]}");
+        }
+
+        return $head ? $head : null;
+    }
+}


### PR DESCRIPTION
An implementation for https://github.com/jpatokal/openflights/issues/1216.

This assumes the deployment point is a git clone.