### PR TITLE
Fix Map Popup "List Flights" Quote Escaping Issue

### DIFF
--- a/openflights.js
+++ b/openflights.js
@@ -457,6 +457,10 @@ function drawAirport(airportLayer, apdata, name, city, country, count, formatted
 
 // Run when the user clicks on an airport marker
 function onAirportSelect(airport) {
+  function encodeURIQuote(str) {
+    return encodeURI(str).replace("'", "&apos;");
+  }
+
   apid = airport.attributes.apid;
   code = airport.attributes.code;
   coreid = airport.attributes.coreid;
@@ -475,7 +479,7 @@ function onAirportSelect(airport) {
       // 3. privacy is set to (O)pen
       if( logged_in || demo_mode || privacy == "O") {
 	// Get list of user flights
-	desc += " <a href='#' onclick='JavaScript:xmlhttpPost(\"" + URL_FLIGHTS + "\"," + apid + ", \"" + encodeURI(airport.attributes.desc) + "\");'><img src='/img/icon_copy.png' width=16 height=16 title='" + gt.gettext("List my flights") + "'></a>";
+	desc += " <a href='#' onclick='JavaScript:xmlhttpPost(\"" + URL_FLIGHTS + "\"," + apid + ", \"" + encodeURIQuote(airport.attributes.desc) + "\");'><img src='/img/icon_copy.png' width=16 height=16 title='" + gt.gettext("List my flights") + "'></a>";
       }
     } else {
       if(code.length == 3) {
@@ -485,7 +489,7 @@ function onAirportSelect(airport) {
 	} else {
 	  idstring = "R" + apid + "," + coreid;
 	}
-	desc += " <a href='#' onclick='JavaScript:xmlhttpPost(\"" + URL_FLIGHTS + "\",\"" + idstring + "\", \"" + encodeURI(rdesc) + "\");'><img src='/img/icon_copy.png' width=16 height=16 title='" + gt.gettext("List routes") + "'></a> ";
+	desc += " <a href='#' onclick='JavaScript:xmlhttpPost(\"" + URL_FLIGHTS + "\",\"" + idstring + "\", \"" + encodeURIQuote(rdesc) + "\");'><img src='/img/icon_copy.png' width=16 height=16 title='" + gt.gettext("List routes") + "'></a> ";
       }
     }
     if(code.length == 3) {


### PR DESCRIPTION
Airports with single quotes in their description (e.g. ORD with its "Chicago O'Hare Internation. (ORD), United States") have their List Flights links broken because of an escaping issue between JS and HTML.

Clicking on the link produces the following error in Firefox:

```
Uncaught SyntaxError: "" string literal contains an unescaped line break
```

The link itself looks like this in HTML:

```txt
<a href="#" onclick="JavaScript:xmlhttpPost(&quot;/php/flights.php&quot;,3830, &quot;Chicago%20O" hare%20international%20airport%20(%3cb%3eord%3c="" b%3e)%3cbr%3e%3csmall%3echicago,%20united%20states%3c="" small%3e%3cbr%3eflights:%203");'=""><img src="/img/icon_copy.png" title="List my flights" width="16" height="16"></a>
```

You can see that the browser stopped parsing the `onclick` quotes right before the quote in "O'Hare". This is because the JS which generated this line of HTML looks like this (slightly abridged):

```js
desc += " <a href='#' onclick='JavaScript:xmlhttpPost(\"" + URL_FLIGHTS + "\"," + apid + ", \"" + encodeURI(airport.attributes.desc) + "\");'>"
```

The single quote right after `onclick` ends up being matched against the quote in the airport description.

Fixes https://github.com/jpatokal/openflights/issues/1220.