### PR TITLE
`alsearch.php` bugfix

### DIFF
--- a/php/alsearch.php
+++ b/php/alsearch.php
@@ -144,7 +144,7 @@ if ($action == "RECORD") {
         printf('1;' . $dbh->lastInsertId() . ';New ' . $modeOperators[$mode] . ' successfully added.');
     } else {
         if ($sth->rowCount() == 1) {
-            printf('1;' . $apid . ';' . _("Airline successfully edited."));
+            printf('1;' . $alid . ';' . _("Airline successfully edited."));
         } else {
             printf('0;' . _("Editing airline failed:") . ' ' . $sql);
         }


### PR DESCRIPTION
When editing an airline, the ID doesn't get returned in the response and we get a PHP notice for an undefined variable (`Undefined variable: apid in /var/www/openflights/php/alsearch.php on line 147"`).

Example response:

```
1;;Airline successfully edited.
```

Expected response:

```
1;21318;Airline successfully edited.
```

This is probably a copy/paste bug. `alsearch.php` (airline search) has nothing to do with `$apid` (airport ID) and wants `$alid` (airline ID) instead. This is clearly the intent based on the if statement condition right above and the matching comments in `alsearch.js`.