### PR TITLE
Open API documentation: login and logout

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,126 @@
+openapi: 3.1.0
+info:
+  version: 0.0.1
+  title: OpenFlights Internal API Documentation
+externalDocs:
+  description: Project source code
+  url: https://github.com/jpatokal/openflights
+tags:
+  - name: login
+    description: User session management
+paths:
+  /php/login.php:
+    post:
+      tags:
+        - login
+      summary: Logs user into the system and creates a session
+      operationId: loginUser
+      parameters:
+        - name: challenge
+          in: query
+          description: Server-generated challenge string returned from the `php/map.php` endpoint
+          required: true
+          schema:
+            type: string
+        - name: name
+          in: query
+          description: The user name for login
+          required: true
+          schema:
+            type: string
+        - name: pw
+          in: query
+          description: The user password as `base64(md5(challenge + md5(password + lowercase(name))))`
+          required: true
+          schema:
+            type: string
+        - name: lpw
+          in: query
+          description: Same as `pw` except the name is not converted to lowercase
+          required: false
+          schema:
+            type: string
+          deprecated: true
+
+      responses:
+        '200':
+          description: The server processed the request. Different types are returned for success/failure.
+          content:
+            application/json:
+              schema:
+                 oneOf:
+                  - $ref: '#/components/schemas/LoginSuccess'
+                  - $ref: '#/components/schemas/LoginFailure'
+
+  /php/logout.php:
+    post:
+      tags:
+        - login
+      summary: Logs out current logged in user session
+      parameters: []
+      responses:
+        '200':
+          description: Successful logout. This response has no content.
+
+components:
+  schemas:
+    DistanceUnit:
+      type: string
+      oneOf:
+      - title: Kilometers
+        const: "K"
+      - title: Miles
+        const: "M"
+    EditorType:
+      type: string
+      oneOf:
+      - title: Basic
+        const: "B"
+      - title: Detailed
+        const: "D"
+    LoginStatus:
+      type: integer
+      oneOf:
+      - title: Failure
+        const: 0
+        description: Invalid username/password or an expired session.
+      - title: Success
+        const: 1
+      - title: Success (reload for user locale)
+        const: 2
+    LoginSuccess:
+      type: object
+      description: "Login success and associated user information"
+      properties:
+        status:
+          $ref: '#/components/schemas/LoginStatus'
+        uid:
+          type: string
+          description: "User ID"
+          example: "123"
+        name:
+          type: string
+          description: "User name"
+          example: "woof"
+        locale:
+          description: "User locale"
+          type: string
+          example: "en_US"
+        units:
+          $ref: '#/components/schemas/DistanceUnit'
+        email:
+          type: string
+          example: "email@example.com"
+        editor:
+          $ref: '#/components/schemas/EditorType'
+        elite:
+          type: string
+    LoginFailure:
+      type: object
+      description: "Login failure and failure message"
+      properties:
+        status:
+          $ref: '#/components/schemas/LoginStatus'
+        message:
+          type: string
+          example: "Login failed"


### PR DESCRIPTION
@jpatokal, @reedy As I'm making changes to the endpoints (to have them return JSON instead of their current bespoke serialization scheme; e.g. #1222), I think it would be nice to start documenting the available endpoints. This should make it easier to review them and to keep them consistent as they are developed (e.g. don't mix numbers/strings for the same value across requests, share object types between endpoints).

Doing this across the board is quite a bit of work so this PR provides minimal coverage for login/logout. If we agree this a good idea, we could build upon this.

You can preview this online by opening https://petstore.swagger.io/ and opening
https://raw.githubusercontent.com/chrisrosset/openflights/openapi-swagger/openapi.yaml
which links to the file on the branch for this PR.

This idea also came up in #876 (in [the linked Google Doc](https://docs.google.com/document/d/1yyNB-yDLVewyNpJ78ZvC3w6K3MB1NUvBFdNNFuET-9c/edit?disco=AAAAC45aHTU)).
