### PR TITLE
Assorted Autocomplete Fixes & Improvements

### DIFF
--- a/openflights.css
+++ b/openflights.css
@@ -207,6 +207,14 @@ td.donate2 {
 }
 
 /* Autocomplete styles */
+.autocomplete {
+ /* TODO: improve this in code review
+  *
+  * We want the autocomplete suggestions to appear *over* the km/mi map
+  * distance measure when displaying them above the text entry. But how?
+  */
+  z-index: 9999;
+}
 .autocomplete > div.selected,
 .autocomplete > div:hover:not(.group) {
   background: #c6deff;

--- a/openflights.css
+++ b/openflights.css
@@ -208,10 +208,9 @@ td.donate2 {
 
 /* Autocomplete styles */
 .autocomplete {
- /* TODO: improve this in code review
-  *
+ /*
   * We want the autocomplete suggestions to appear *over* the km/mi map
-  * distance measure when displaying them above the text entry. But how?
+  * distance measure when displaying them above the text entry.
   */
   z-index: 9999;
 }

--- a/openflights.js
+++ b/openflights.js
@@ -620,6 +620,14 @@ function prepareAutocomplete(inputId, { successCb, failureCb }) {
       inputElement.value = item.label;
       successCb(item);
     },
+    customize: (input, inputRect, container, maxHeight) => {
+      if (maxHeight < 100) {
+        container.style.top = "";
+        container.style.bottom =
+          window.innerHeight - inputRect.bottom + input.offsetHeight + "px";
+        container.style.maxHeight = "200px";
+      }
+    },
   });
 }
 

--- a/openflights.js
+++ b/openflights.js
@@ -444,7 +444,7 @@ function init() {
     for (const airportAutoCompInputId of ac_airport) {
       prepareAutocomplete(airportAutoCompInputId, "airport", {
         successCb: (item) => {
-          inputElement.value = item.label;
+          document.getElementById(airportAutoCompInputId).value = item.label;
           getSelectedApid(airportAutoCompInputId, item.value);
         },
         failureCb: (error) => {
@@ -456,7 +456,7 @@ function init() {
     for (const airlineAutoCompInputId of ac_airline) {
       prepareAutocomplete(airlineAutoCompInputId, "airline", {
         successCb: (item) => {
-          inputElement.value = item.label;
+          document.getElementById(airlineAutoCompInputId).value = item.label;
           getSelectedAlid(airlineAutoCompInputId, item.value);
         },
       });
@@ -464,8 +464,24 @@ function init() {
 
     for (const planeAutoCompInputId of ac_plane) {
       prepareAutocomplete(planeAutoCompInputId, "plane", {
+        preprocessCb: (list) =>
+          list.map((item) => {
+            // Logic moved from `autocomplete.php` to house presentation details
+            // in the UI. But why are planes special? We don't shorten airport
+            // or airline names. Is it because that input field isn't as wide?
+            // This is the only type of autocomplete that needs this kind of
+            // preprocessing...
+            const maxLen = 35;
+            let label = item.label;
+            if (label.length > maxLen) {
+              label = `${label.slice(0, maxLen - 13)}...${label.slice(-10)}`;
+            }
+
+            item.label = label;
+            return item;
+          }),
         successCb: (item) => {
-          inputElement.value = item.label;
+          document.getElementById(planeAutoCompInputId).value = item.label;
           getSelectedPlid(planeAutoCompInputId, item.value);
         },
       });
@@ -576,13 +592,17 @@ function drawLine(x1, y1, x2, y2, count, distance, color, stroke) {
 // `autocomplete.js` wrapper to encapsulate logic dealing with setting up the
 // autocomplete widgets and interacting with the autocomplete API endpoint.
 //
-function prepareAutocomplete(inputId, searchType, { successCb, failureCb }) {
+function prepareAutocomplete(
+  inputId,
+  searchType,
+  { successCb, failureCb, preprocessCb }
+) {
   const inputElement = document.getElementById(inputId);
 
   autocomplete({
     input: inputElement,
     minLength: 1,
-    debounceWaitMs: 300,
+    debounceWaitMs: 100,
     fetch: (text, update) => {
       showLoadingAnimation(true);
       fetch(URL_GETCODE, {
@@ -602,7 +622,14 @@ function prepareAutocomplete(inputId, searchType, { successCb, failureCb }) {
           }
           return response.json();
         })
-        .then((data) => {
+        .then((response) => {
+          let data = response;
+          if (preprocessCb) data = preprocessCb(data);
+
+          if (data.length === 0) {
+            throw new Error("No data available");
+          }
+
           update(data);
         })
         .catch((e) => {
@@ -938,7 +965,6 @@ function xmlhttpPost(strURL, id, param) {
         } else {
           cols = [""];
         }
-        console.log("cols", cols);
         switch (param) {
           case "qs":
             var alid = cols[0];
@@ -2871,7 +2897,7 @@ function getSelectedPlid(inputElementId, plid) {
 /// Autocompleted airport or airline
 /// item -- selected autocomplete item with data from the API {label, value}
 function getQuickSearchId(item) {
-  const data = item.value;
+  const data = item.value.toString();
   let id;
   if (data.indexOf(":") > 0) {
     // code:apid:x:y

--- a/openflights.js
+++ b/openflights.js
@@ -409,7 +409,7 @@ function init() {
       query = arguments[1];
   }
 
-  prepareAutocomplete("qs", "quick", {
+  prepareAutocomplete("qs", "multisearch", {
     successCb: getQuickSearchId,
     failureCb: (e) => undefined,
   });
@@ -444,6 +444,7 @@ function init() {
     for (const airportAutoCompInputId of ac_airport) {
       prepareAutocomplete(airportAutoCompInputId, "airport", {
         successCb: (item) => {
+          inputElement.value = item.label;
           getSelectedApid(airportAutoCompInputId, item.value);
         },
         failureCb: (error) => {
@@ -455,6 +456,7 @@ function init() {
     for (const airlineAutoCompInputId of ac_airline) {
       prepareAutocomplete(airlineAutoCompInputId, "airline", {
         successCb: (item) => {
+          inputElement.value = item.label;
           getSelectedAlid(airlineAutoCompInputId, item.value);
         },
       });
@@ -463,6 +465,7 @@ function init() {
     for (const planeAutoCompInputId of ac_plane) {
       prepareAutocomplete(planeAutoCompInputId, "plane", {
         successCb: (item) => {
+          inputElement.value = item.label;
           getSelectedPlid(planeAutoCompInputId, item.value);
         },
       });
@@ -589,31 +592,18 @@ function prepareAutocomplete(inputId, searchType, { successCb, failureCb }) {
         },
         body: encodeURI(`${inputId}=${text}`),
         body: new URLSearchParams([
-          // legacy format for backwards-compatibility
-          [inputId, text],
-          // new format
-          ['searchType', searchType],
-          ['searchText', text]
-        ])
+          ["searchType", searchType],
+          ["searchText", text],
+        ]),
       })
         .then((response) => {
           if (response.status !== 200) {
             throw new Error(response.status);
           }
-          return response.text();
+          return response.json();
         })
-        .then((text) => {
-          const responseXML = new DOMParser().parseFromString(text, "text/xml");
-
-          const suggestions = [];
-          const ul = responseXML.firstChild;
-          ul.childNodes.forEach((elem) => {
-            // Skip over newline text nodes
-            if (elem.nodeName === "li")
-              suggestions.push({ label: elem.firstChild.data, value: elem.id });
-          });
-
-          update(suggestions);
+        .then((data) => {
+          update(data);
         })
         .catch((e) => {
           if (failureCb) failureCb(e);
@@ -624,7 +614,6 @@ function prepareAutocomplete(inputId, searchType, { successCb, failureCb }) {
         });
     },
     onSelect: (item) => {
-      inputElement.value = item.label;
       successCb(item);
     },
     customize: (input, inputRect, container, maxHeight) => {
@@ -941,7 +930,15 @@ function xmlhttpPost(strURL, id, param) {
         showLoadingAnimation(false);
       }
       if (strURL == URL_GETCODE) {
-        var cols = self.xmlHttpReq.responseText.split(";");
+        const resp = JSON.parse(self.xmlHttpReq.responseText);
+        var cols;
+        // Hack the old format back in (for now)
+        if (resp.length) {
+          cols = [resp[0].value, resp[0].label];
+        } else {
+          cols = [""];
+        }
+        console.log("cols", cols);
         switch (param) {
           case "qs":
             var alid = cols[0];
@@ -1359,11 +1356,10 @@ function xmlhttpPost(strURL, id, param) {
 
     case URL_GETCODE:
       const getcodeParams = new URLSearchParams();
-      getcodeParams.set('mode', getMode());
-      getcodeParams.set(param, id);
-      getcodeParams.set('searchType', 'quick');
-      getcodeParams.set('searchText', id);
-      getcodeParams.set('quick', true);
+      getcodeParams.set("mode", getMode());
+      getcodeParams.set("searchType", "multisearch");
+      getcodeParams.set("searchText", id);
+      getcodeParams.set("quick", true);
       query = getcodeParams.toString();
       break;
 
@@ -2884,6 +2880,7 @@ function getQuickSearchId(item) {
   } else {
     id = `L${data}`;
   }
+  $("qs").value = item.label;
   $("qsid").value = id;
   $("qsgo").disabled = false;
 }

--- a/php/autocomplete.php
+++ b/php/autocomplete.php
@@ -3,6 +3,7 @@
 include_once 'helper.php';
 include_once 'db_pdo.php';
 
+// TODO: Why do we do this?
 /**
  * Trim anything after a hyphen, period or left paren
  * @param $query
@@ -12,6 +13,8 @@ function trim_query($query) {
     $chunks = preg_split("/[-.(]/", $query);
     return trim($chunks[0]);
 }
+
+header("Content-type: application/json; charset=utf-8");
 
 const SEARCH_TYPES = array("airport", "airline", "plane", "multisearch");
 
@@ -25,6 +28,7 @@ $searchType = $_POST['searchType'];
 $searchText = trim_query($_POST['searchText']);
 
 if (empty($searchText)) {
+    echo json_encode([]);
     exit;
 }
 
@@ -152,12 +156,8 @@ SQL;
     $MAX_LEN = 35;
     foreach ($sth as $data) {
         $name = $data['name'];
-        if (strlen($name) > $MAX_LEN) {
-            $name = substr($name, 0, $MAX_LEN - 13) . "..." . substr($name, -10, 10);
-        }
         $results[] = ['label' => $name, 'value' => (int)$data['plid']];
     }
 }
 
-header("Content-type: application/json; charset=utf-8");
 echo json_encode($results);

--- a/php/autocomplete.php
+++ b/php/autocomplete.php
@@ -156,27 +156,29 @@ if (!$query || $multi) {
                 }
             }
         }
-    } elseif ($_POST['plane']) {
-        // Autocompletion for plane types
-        // First match against major types with IATA codes, then pad to max 6 by matching against frequency of use
-        $query = $_POST['plane'];
-        $name = "%$query%";
-        $query = "(name LIKE :name OR iata LIKE :name) ";
-        $sql = "(SELECT name,plid FROM planes WHERE " . $query . " AND iata IS NOT NULL ORDER BY name LIMIT 6) UNION " .
-        "(SELECT name,plid FROM planes WHERE " . $query . " AND iata IS NULL ORDER BY frequency DESC LIMIT 6) LIMIT 6";
-        $sth = $dbh->prepare($sql);
-        $sth->execute(compact('name'));
+    }
+}
 
-        print("<ul class='autocomplete2'>");
-        $MAX_LEN = 35;
-        foreach ($sth as $data) {
-            $results = true;
-            $item = stripslashes($data['name']);
-            if (strlen($item) > $MAX_LEN) {
-                $item = substr($item, 0, $MAX_LEN - 13) . "..." . substr($item, -10, 10);
-            }
-            echo "<li class='autocomplete' id='" . $data['plid'] . "'>" . $item . "</li>";
+if ($_POST['plane']) {
+    // Autocompletion for plane types
+    // First match against major types with IATA codes, then pad to max 6 by matching against frequency of use
+    $query = $_POST['plane'];
+    $name = "%$query%";
+    $filter = "(name LIKE :name OR iata LIKE :name) ";
+    $sql = "(SELECT name,plid FROM planes WHERE " . $filter . " AND iata IS NOT NULL ORDER BY name LIMIT 6) UNION " .
+    "(SELECT name,plid FROM planes WHERE " . $filter . " AND iata IS NULL ORDER BY frequency DESC LIMIT 6) LIMIT 6";
+    $sth = $dbh->prepare($sql);
+    $sth->execute(compact('name'));
+
+    print("<ul class='autocomplete2'>");
+    $MAX_LEN = 35;
+    foreach ($sth as $data) {
+        $results = true;
+        $item = stripslashes($data['name']);
+        if (strlen($item) > $MAX_LEN) {
+            $item = substr($item, 0, $MAX_LEN - 13) . "..." . substr($item, -10, 10);
         }
+        echo "<li class='autocomplete' id='" . $data['plid'] . "'>" . $item . "</li>";
     }
 }
 

--- a/php/autocomplete.php
+++ b/php/autocomplete.php
@@ -32,17 +32,6 @@ $airports = array("qs", "src_ap", "dst_ap", "src_ap1", "dst_ap1", "src_ap2", "ds
 foreach ($airports as $ap) {
     if ($_POST[$ap]) {
         $query = trim_query($_POST[$ap]);
-        // Limit the number of rows returned in multi-input, where space is at a premium
-        if ($limit > 1) {
-            $idx = substr($ap, -1);
-            switch ($idx) {
-                case "4":
-                case "3":
-                case "2":
-                case "1":
-                    $limit = 7 - $idx;
-            }
-        }
         break;
     }
 }
@@ -112,20 +101,6 @@ if (!$query || $multi) {
     foreach ($airlines as $al) {
         if ($_POST[$al]) {
             $query = trim_query($_POST[$al]);
-            // Limit(/expand) the number of rows returned in multiinput, where space is at a premium
-            if ($limit != 1) {
-                $idx = substr($al, -1);
-                switch ($idx) {
-                    case "4":
-                    case "3":
-                    case "2":
-                    case "1":
-                        $limit = 7 - $idx;
-                        break;
-                    default:
-                        $limit = 3;
-                }
-            }
             break;
         }
     }


### PR DESCRIPTION
- Autocomplete display improvement for multi-input flight mode. Instead of decreasing the number of suggestions to control the size of the popup, we show it above the entry field. Fixes #1283.
- Fixed parameter encoding issues on the way to the server.
- Changed the parameter scheme for the endpoint to reduce coupling. The server no longer cares about the `id` of the `input` the search is for - it only cares about the type (airlines, airports, planes, mixed aka multisearch). Closes #1269.
- Converted server responses to JSON (fixes #1272).
- General refactoring of `autocomplete.php` to improve naming, fix warnings, simplify flow, etc.
- Moved some presentation logic to the UI.

I would love to remove the last autocomplete requests from `xmlHttpPost`... Those aren't really autocomplete as much as matching airline/airport codes and would probably be better done by making requests to the airport/airline search APIs but those are not that great either right now so I've just patched things for now. This behavior only happens when you tab out of the entry fields - but not if you change focus with the mouse... Would be great to remove that but then you'd have to "type, enter, tab" instead of "type, tab"... but maybe it's not that big of a deal?