### PR TITLE
Further GitHub issue improvements

### DIFF
--- a/html/apsearch.php
+++ b/html/apsearch.php
@@ -33,7 +33,7 @@ $logged_in = $uid && !empty($uid);
         <tr>
           <td><?php echo _("Airport name"); ?></td>
           <td title="<?php
-            echo _('International Air Transport Association') . _('Federal Aviation Administration');
+            echo _('International Air Transport Association') . '/' . _('Federal Aviation Administration');
             ?>">
               <?php echo _('IATA'); ?>/<?php echo _('FAA'); ?>
           </td>

--- a/js/apsearch.js
+++ b/js/apsearch.js
@@ -310,7 +310,7 @@ function xmlhttpPost(strURL, offset, action) {
       }
     }
 
-    // Build new query
+    // Build a new query
     if (action != "SEARCH" || (action == "SEARCH" && offset == 0)) {
       query =
         "name=" +
@@ -361,7 +361,7 @@ function xmlhttpPost(strURL, offset, action) {
   }
   var box = getElement("miniresultbox");
   box.style.color = "#222";
-  box.innerHTML = "<p><i>" + gt.gettext(describe(action)) + "</i></p>";
+  box.innerHTML = "<p><i>" + describe(action) + "</i></p>";
   self.xmlHttpReq.send(query + "&offset=" + offset);
 }
 
@@ -369,11 +369,11 @@ function describe(action) {
   // Localised in usage above
   switch (action) {
     case "SEARCH":
-      return "Searching...";
+      return gt.gettext("Searching...");
     case "LOAD":
-      return "Loading...";
+      return gt.gettext("Loading...");
     case "RECORD":
-      return "Recording...";
+      return gt.gettext("Recording...");
   }
 }
 
@@ -384,7 +384,7 @@ function searchResult(str) {
   var json = JSON.parse(str);
   var airports = json["airports"];
   var table = "<table width=95% cellspacing=0>";
-  var offset, sql;
+  var offset = json["offset"];
   var db = document.forms["searchform"].db.value;
   var disclaimer = "";
 
@@ -396,7 +396,6 @@ function searchResult(str) {
     warning = null;
   }
 
-  offset = json["offset"];
   var max = json["max"];
   if (max == 0) {
     table +=
@@ -408,12 +407,14 @@ function searchResult(str) {
         "<li>" +
         gt.gettext(
           "Try unchecking 'Show only major airports' and search again."
-        );
+        ) +
+        "</li>";
     }
     if (document.forms["searchform"].db.value != DB_OURAIRPORTS) {
       table +=
         "<li>" +
-        gt.gettext("Switch to the OurAirports database and search again.");
+        gt.gettext("Switch to the OurAirports database and search again.") +
+        "</li>";
     }
     table += "</ul></td></tr>";
   } else {
@@ -478,6 +479,7 @@ function searchResult(str) {
             "<span>";
           break;
       }
+
       table +=
         "<tr><td style='background-color: " +
         bgcolor +
@@ -568,7 +570,6 @@ function loadAirport(data) {
   }
   var dst_select = form.dst;
   for (index = 0; index < dst_select.length; index++) {
-    //alert(dst_select[index].value + "/" + col["dst"]);
     if (dst_select[index].value == col["dst"]) {
       dst_select.selectedIndex = index;
     }
@@ -586,8 +587,8 @@ function loadAirport(data) {
 // Did we manage to record the airport?
 function recordResult(str) {
   var json = JSON.parse(str);
-  // Success
   var box = getElement("miniresultbox");
+  // Success
   if (json["status"] == "1") {
     alert(json["message"]);
     // Select newly minted airport and return to main
@@ -608,9 +609,13 @@ function recordResult(str) {
       code +
       "), " +
       country;
+    // TODO: The alert is annoying... Change the save button for select instead?
+    // https://github.com/jpatokal/openflights/issues/1352
     selectAirport(data, name);
+    // Probably should be green/blue for some sort of success
     box.style.color = "#222";
   } else {
+    // Red for error
     box.style.color = "#FF0000";
   }
   box.innerHTML = "<p>" + json["message"] + "</p>";
@@ -627,7 +632,7 @@ function setEdited() {
   }
 }
 
-// Clear form -- everything *except* database
+// Clear form -- everything *except* the database
 function clearSearch() {
   var form = document.forms["searchform"];
   form.airport.value = "";

--- a/locale/de_DE.utf8/LC_MESSAGES/messages.po
+++ b/locale/de_DE.utf8/LC_MESSAGES/messages.po
@@ -2755,6 +2755,30 @@ msgstr ""
 msgid "Operation %s failed."
 msgstr ""
 
+#, php-format
+msgid ""
+"Airport addition comment submitted for review on existing GitHub Issue: %s; "
+"%s"
+msgstr ""
+
+#, php-format
+msgid ""
+"Airport edit comment submitted for review on existing GitHub Issue: %s; %s"
+msgstr ""
+
+#, php-format
+msgid "Airport addition issue created for review on new GitHub Issue: %s; %s"
+msgstr ""
+
+#, php-format
+msgid "Airport edit issue created for review on new GitHub Issue:  %s; %s"
+msgstr ""
+
+msgid ""
+"Could not submit edit for review, please contact <a href='/about'>support</"
+"a>."
+msgstr ""
+
 msgid "Error"
 msgstr "Fehler"
 
@@ -3769,6 +3793,9 @@ msgid "Platinum Elite"
 msgstr ""
 
 msgid "Thank you for using OpenFlights &mdash; please donate!"
+msgstr ""
+
+msgid "Valid until"
 msgstr ""
 
 msgid "Creating account..."

--- a/locale/en_GB.utf8/LC_MESSAGES/messages.po
+++ b/locale/en_GB.utf8/LC_MESSAGES/messages.po
@@ -2723,6 +2723,30 @@ msgstr ""
 msgid "Operation %s failed."
 msgstr ""
 
+#, php-format
+msgid ""
+"Airport addition comment submitted for review on existing GitHub Issue: %s; "
+"%s"
+msgstr ""
+
+#, php-format
+msgid ""
+"Airport edit comment submitted for review on existing GitHub Issue: %s; %s"
+msgstr ""
+
+#, php-format
+msgid "Airport addition issue created for review on new GitHub Issue: %s; %s"
+msgstr ""
+
+#, php-format
+msgid "Airport edit issue created for review on new GitHub Issue:  %s; %s"
+msgstr ""
+
+msgid ""
+"Could not submit edit for review, please contact <a href='/about'>support</"
+"a>."
+msgstr ""
+
 msgid "Error"
 msgstr ""
 
@@ -3650,6 +3674,9 @@ msgid "Platinum Elite"
 msgstr ""
 
 msgid "Thank you for using OpenFlights &mdash; please donate!"
+msgstr ""
+
+msgid "Valid until"
 msgstr ""
 
 msgid "Creating account..."

--- a/locale/es_ES.utf8/LC_MESSAGES/messages.po
+++ b/locale/es_ES.utf8/LC_MESSAGES/messages.po
@@ -2757,6 +2757,30 @@ msgstr ""
 msgid "Operation %s failed."
 msgstr ""
 
+#, php-format
+msgid ""
+"Airport addition comment submitted for review on existing GitHub Issue: %s; "
+"%s"
+msgstr ""
+
+#, php-format
+msgid ""
+"Airport edit comment submitted for review on existing GitHub Issue: %s; %s"
+msgstr ""
+
+#, php-format
+msgid "Airport addition issue created for review on new GitHub Issue: %s; %s"
+msgstr ""
+
+#, php-format
+msgid "Airport edit issue created for review on new GitHub Issue:  %s; %s"
+msgstr ""
+
+msgid ""
+"Could not submit edit for review, please contact <a href='/about'>support</"
+"a>."
+msgstr ""
+
 msgid "Error"
 msgstr "Error"
 
@@ -3781,6 +3805,9 @@ msgid "Platinum Elite"
 msgstr ""
 
 msgid "Thank you for using OpenFlights &mdash; please donate!"
+msgstr ""
+
+msgid "Valid until"
 msgstr ""
 
 msgid "Creating account..."

--- a/locale/fi_FI.utf8/LC_MESSAGES/messages.po
+++ b/locale/fi_FI.utf8/LC_MESSAGES/messages.po
@@ -2717,6 +2717,30 @@ msgstr ""
 msgid "Operation %s failed."
 msgstr ""
 
+#, php-format
+msgid ""
+"Airport addition comment submitted for review on existing GitHub Issue: %s; "
+"%s"
+msgstr ""
+
+#, php-format
+msgid ""
+"Airport edit comment submitted for review on existing GitHub Issue: %s; %s"
+msgstr ""
+
+#, php-format
+msgid "Airport addition issue created for review on new GitHub Issue: %s; %s"
+msgstr ""
+
+#, php-format
+msgid "Airport edit issue created for review on new GitHub Issue:  %s; %s"
+msgstr ""
+
+msgid ""
+"Could not submit edit for review, please contact <a href='/about'>support</"
+"a>."
+msgstr ""
+
 msgid "Error"
 msgstr "Virhe"
 
@@ -3694,6 +3718,9 @@ msgid "Platinum Elite"
 msgstr ""
 
 msgid "Thank you for using OpenFlights &mdash; please donate!"
+msgstr ""
+
+msgid "Valid until"
 msgstr ""
 
 msgid "Creating account..."

--- a/locale/fr_FR.utf8/LC_MESSAGES/messages.po
+++ b/locale/fr_FR.utf8/LC_MESSAGES/messages.po
@@ -2757,6 +2757,30 @@ msgstr ""
 msgid "Operation %s failed."
 msgstr ""
 
+#, php-format
+msgid ""
+"Airport addition comment submitted for review on existing GitHub Issue: %s; "
+"%s"
+msgstr ""
+
+#, php-format
+msgid ""
+"Airport edit comment submitted for review on existing GitHub Issue: %s; %s"
+msgstr ""
+
+#, php-format
+msgid "Airport addition issue created for review on new GitHub Issue: %s; %s"
+msgstr ""
+
+#, php-format
+msgid "Airport edit issue created for review on new GitHub Issue:  %s; %s"
+msgstr ""
+
+msgid ""
+"Could not submit edit for review, please contact <a href='/about'>support</"
+"a>."
+msgstr ""
+
 msgid "Error"
 msgstr "Erreur"
 
@@ -3768,6 +3792,9 @@ msgid "Platinum Elite"
 msgstr ""
 
 msgid "Thank you for using OpenFlights &mdash; please donate!"
+msgstr ""
+
+msgid "Valid until"
 msgstr ""
 
 msgid "Creating account..."

--- a/locale/ja_JP.utf8/LC_MESSAGES/messages.po
+++ b/locale/ja_JP.utf8/LC_MESSAGES/messages.po
@@ -2709,6 +2709,30 @@ msgstr ""
 msgid "Operation %s failed."
 msgstr ""
 
+#, php-format
+msgid ""
+"Airport addition comment submitted for review on existing GitHub Issue: %s; "
+"%s"
+msgstr ""
+
+#, php-format
+msgid ""
+"Airport edit comment submitted for review on existing GitHub Issue: %s; %s"
+msgstr ""
+
+#, php-format
+msgid "Airport addition issue created for review on new GitHub Issue: %s; %s"
+msgstr ""
+
+#, php-format
+msgid "Airport edit issue created for review on new GitHub Issue:  %s; %s"
+msgstr ""
+
+msgid ""
+"Could not submit edit for review, please contact <a href='/about'>support</"
+"a>."
+msgstr ""
+
 msgid "Error"
 msgstr "エラー"
 
@@ -3674,6 +3698,9 @@ msgid "Platinum Elite"
 msgstr ""
 
 msgid "Thank you for using OpenFlights &mdash; please donate!"
+msgstr ""
+
+msgid "Valid until"
 msgstr ""
 
 msgid "Creating account..."

--- a/locale/lt_LT.utf8/LC_MESSAGES/messages.po
+++ b/locale/lt_LT.utf8/LC_MESSAGES/messages.po
@@ -2749,6 +2749,30 @@ msgstr ""
 msgid "Operation %s failed."
 msgstr ""
 
+#, php-format
+msgid ""
+"Airport addition comment submitted for review on existing GitHub Issue: %s; "
+"%s"
+msgstr ""
+
+#, php-format
+msgid ""
+"Airport edit comment submitted for review on existing GitHub Issue: %s; %s"
+msgstr ""
+
+#, php-format
+msgid "Airport addition issue created for review on new GitHub Issue: %s; %s"
+msgstr ""
+
+#, php-format
+msgid "Airport edit issue created for review on new GitHub Issue:  %s; %s"
+msgstr ""
+
+msgid ""
+"Could not submit edit for review, please contact <a href='/about'>support</"
+"a>."
+msgstr ""
+
 msgid "Error"
 msgstr "Klaida"
 
@@ -3763,6 +3787,9 @@ msgid "Platinum Elite"
 msgstr ""
 
 msgid "Thank you for using OpenFlights &mdash; please donate!"
+msgstr ""
+
+msgid "Valid until"
 msgstr ""
 
 msgid "Creating account..."

--- a/locale/nl_NL.utf8/LC_MESSAGES/messages.po
+++ b/locale/nl_NL.utf8/LC_MESSAGES/messages.po
@@ -2723,6 +2723,30 @@ msgstr ""
 msgid "Operation %s failed."
 msgstr ""
 
+#, php-format
+msgid ""
+"Airport addition comment submitted for review on existing GitHub Issue: %s; "
+"%s"
+msgstr ""
+
+#, php-format
+msgid ""
+"Airport edit comment submitted for review on existing GitHub Issue: %s; %s"
+msgstr ""
+
+#, php-format
+msgid "Airport addition issue created for review on new GitHub Issue: %s; %s"
+msgstr ""
+
+#, php-format
+msgid "Airport edit issue created for review on new GitHub Issue:  %s; %s"
+msgstr ""
+
+msgid ""
+"Could not submit edit for review, please contact <a href='/about'>support</"
+"a>."
+msgstr ""
+
 msgid "Error"
 msgstr "Fout"
 
@@ -3720,6 +3744,9 @@ msgid "Platinum Elite"
 msgstr ""
 
 msgid "Thank you for using OpenFlights &mdash; please donate!"
+msgstr ""
+
+msgid "Valid until"
 msgstr ""
 
 msgid "Creating account..."

--- a/locale/pl_PL.utf8/LC_MESSAGES/messages.po
+++ b/locale/pl_PL.utf8/LC_MESSAGES/messages.po
@@ -2712,6 +2712,30 @@ msgstr ""
 msgid "Operation %s failed."
 msgstr ""
 
+#, php-format
+msgid ""
+"Airport addition comment submitted for review on existing GitHub Issue: %s; "
+"%s"
+msgstr ""
+
+#, php-format
+msgid ""
+"Airport edit comment submitted for review on existing GitHub Issue: %s; %s"
+msgstr ""
+
+#, php-format
+msgid "Airport addition issue created for review on new GitHub Issue: %s; %s"
+msgstr ""
+
+#, php-format
+msgid "Airport edit issue created for review on new GitHub Issue:  %s; %s"
+msgstr ""
+
+msgid ""
+"Could not submit edit for review, please contact <a href='/about'>support</"
+"a>."
+msgstr ""
+
 msgid "Error"
 msgstr "Błąd"
 
@@ -3667,6 +3691,9 @@ msgid "Platinum Elite"
 msgstr ""
 
 msgid "Thank you for using OpenFlights &mdash; please donate!"
+msgstr ""
+
+msgid "Valid until"
 msgstr ""
 
 msgid "Creating account..."

--- a/locale/pt_BR.utf8/LC_MESSAGES/messages.po
+++ b/locale/pt_BR.utf8/LC_MESSAGES/messages.po
@@ -2751,6 +2751,30 @@ msgstr ""
 msgid "Operation %s failed."
 msgstr ""
 
+#, php-format
+msgid ""
+"Airport addition comment submitted for review on existing GitHub Issue: %s; "
+"%s"
+msgstr ""
+
+#, php-format
+msgid ""
+"Airport edit comment submitted for review on existing GitHub Issue: %s; %s"
+msgstr ""
+
+#, php-format
+msgid "Airport addition issue created for review on new GitHub Issue: %s; %s"
+msgstr ""
+
+#, php-format
+msgid "Airport edit issue created for review on new GitHub Issue:  %s; %s"
+msgstr ""
+
+msgid ""
+"Could not submit edit for review, please contact <a href='/about'>support</"
+"a>."
+msgstr ""
+
 msgid "Error"
 msgstr "Erro"
 
@@ -3758,6 +3782,9 @@ msgid "Platinum Elite"
 msgstr ""
 
 msgid "Thank you for using OpenFlights &mdash; please donate!"
+msgstr ""
+
+msgid "Valid until"
 msgstr ""
 
 msgid "Creating account..."

--- a/locale/ru_RU.utf8/LC_MESSAGES/messages.po
+++ b/locale/ru_RU.utf8/LC_MESSAGES/messages.po
@@ -2749,6 +2749,30 @@ msgstr ""
 msgid "Operation %s failed."
 msgstr ""
 
+#, php-format
+msgid ""
+"Airport addition comment submitted for review on existing GitHub Issue: %s; "
+"%s"
+msgstr ""
+
+#, php-format
+msgid ""
+"Airport edit comment submitted for review on existing GitHub Issue: %s; %s"
+msgstr ""
+
+#, php-format
+msgid "Airport addition issue created for review on new GitHub Issue: %s; %s"
+msgstr ""
+
+#, php-format
+msgid "Airport edit issue created for review on new GitHub Issue:  %s; %s"
+msgstr ""
+
+msgid ""
+"Could not submit edit for review, please contact <a href='/about'>support</"
+"a>."
+msgstr ""
+
 msgid "Error"
 msgstr "Ошибка"
 
@@ -3751,6 +3775,9 @@ msgid "Platinum Elite"
 msgstr ""
 
 msgid "Thank you for using OpenFlights &mdash; please donate!"
+msgstr ""
+
+msgid "Valid until"
 msgstr ""
 
 msgid "Creating account..."

--- a/locale/sv_SE.utf8/LC_MESSAGES/messages.po
+++ b/locale/sv_SE.utf8/LC_MESSAGES/messages.po
@@ -2747,6 +2747,30 @@ msgstr ""
 msgid "Operation %s failed."
 msgstr ""
 
+#, php-format
+msgid ""
+"Airport addition comment submitted for review on existing GitHub Issue: %s; "
+"%s"
+msgstr ""
+
+#, php-format
+msgid ""
+"Airport edit comment submitted for review on existing GitHub Issue: %s; %s"
+msgstr ""
+
+#, php-format
+msgid "Airport addition issue created for review on new GitHub Issue: %s; %s"
+msgstr ""
+
+#, php-format
+msgid "Airport edit issue created for review on new GitHub Issue:  %s; %s"
+msgstr ""
+
+msgid ""
+"Could not submit edit for review, please contact <a href='/about'>support</"
+"a>."
+msgstr ""
+
 msgid "Error"
 msgstr "Fel"
 
@@ -3746,6 +3770,9 @@ msgid "Platinum Elite"
 msgstr ""
 
 msgid "Thank you for using OpenFlights &mdash; please donate!"
+msgstr ""
+
+msgid "Valid until"
 msgstr ""
 
 msgid "Creating account..."

--- a/locale/template.pot
+++ b/locale/template.pot
@@ -2855,3 +2855,25 @@ msgstr ""
 
 msgid "Deleting trip cancelled."
 msgstr ""
+
+#, php-format
+msgid "Airport addition comment submitted for review on existing GitHub Issue: %s; %s"
+msgstr ""
+
+#, php-format
+msgid "Airport edit comment submitted for review on existing GitHub Issue: %s; %s"
+msgstr ""
+
+#, php-format
+msgid "Airport addition issue created for review on new GitHub Issue: %s; %s"
+msgstr ""
+
+#, php-format
+msgid "Airport edit issue created for review on new GitHub Issue:  %s; %s"
+msgstr ""
+
+msgid "Could not submit edit for review, please contact <a href='/about'>support</a>."
+msgstr ""
+
+msgid "Valid until"
+msgstr ""

--- a/test/server/apsearch.php
+++ b/test/server/apsearch.php
@@ -52,8 +52,8 @@ class RecordAirportDuplicateTest extends WebTestCase {
         $params += array("action" => "RECORD", "unittest" => "true");
         $msg = $this->post($webroot . "php/apsearch.php", $params);
 
-        $this->assertText('Update airport AutoTest Airport (ZZZ/ZZZZ)');
-        $this->assertText('New airport edit suggestion submitted by autotest:');
+        $this->assertText('Add airport AutoTest Airport (ZZZ/ZZZZ)');
+        $this->assertText('New airport addition suggestion submitted by autotest:');
         $this->assertText("[name] => " . $airport["name"]);
     }
 }


### PR DESCRIPTION
Further GitHub issue improvements

- Issue subject now varies if it's an addition or an edit
   - Fixes https://github.com/jpatokal/openflights/issues/354 by changing the subject if it's an addition or an edit
   - Also varies success message displayed to user
- Search for more specific issue subject
   - Looking specifically for an open issue, perferably with label:airport
   - First look for the the exact subject we'd be creating
   - Then looking for the other subject (which may be the old style, which was just "update")
   - And then look for the "($iata/$icao)" string, optionally with either missing, incase someone submitted an issue without on before
   - And stops looking for any task with the IATA/ICAO anywhere in the title (many false positives)
   - Will add label:airport to an existing (open) task if it doesn't have it already
   - Fixes https://github.com/jpatokal/openflights/issues/1318
- Improve issue/comment body
   - Only output possible duplicate list if there's any
   - Output cross search strings specifically for icao and iata if they are not empty strings
   - Output a search for the airport name
- Some code reordering so we only do some setup if we need it
   - Explicit exits so we can unindent some large blocks too