### PR TITLE
Config setting for enabling/disabling signups

### DIFF
--- a/html/settings.php
+++ b/html/settings.php
@@ -1,10 +1,16 @@
 <?php
 
+require_once "../php/config.php";
 require_once "../php/locale.php";
 require_once "../php/db_pdo.php";
 require_once "../php/helper.php";
 
 $type = isset($_GET["new"]) ? "signup" : "settings";
+
+if (isset($OF_ENABLE_SIGNUP) && !$OF_ENABLE_SIGNUP) {
+  http_response_code(403);
+  exit;
+}
 
 ?>
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">

--- a/index.php
+++ b/index.php
@@ -101,9 +101,13 @@ require_once "./php/helper.php";
           <tr>
             <td></td>
             <td>
-              <input id="loginbutton" type="button" value="<?php echo _("Log in");
-                ?>" align="middle" tabindex="3" onclick='JavaScript:xmlhttpPost("/php/login.php")'>
-                <h7><a href="/html/settings?new=yes"><?php echo _("Sign up"); ?></a></h7>
+              <input id="loginbutton" type="button" value="<?php echo _("Log in"); ?>"
+                     align="middle" tabindex="3" onclick='JavaScript:xmlhttpPost("/php/login.php")'>
+              <?php
+                if (!isset($OF_ENABLE_SIGNUP) || $OF_ENABLE_SIGNUP) {
+                  echo '<h7><a href="/html/settings?new=yes">', _("Sign up"), "</a></h7>";
+                }
+              ?>
             </td>
           </tr>
         </table>

--- a/php/config.php.sample
+++ b/php/config.php.sample
@@ -21,6 +21,9 @@ $GITHUB_ACCESS_TOKEN = "YOUR_TOKEN";
 // True requires PHP gettext extension, false works only if the extension is *not* installed
 $OF_USE_LOCALES = true;
 
+// Allow the creation of new accounts?
+$OF_ENABLE_SIGNUP = true;
+
 // OpenFlights UID for admin user(s), used only for special access to airport/airline DBs
 // Historically, this was an integer, but now it accepts an array of integers.
 $OF_ADMIN_UID = [ 3 ];


### PR DESCRIPTION
For running a private instance of OpenFlights which does not want to offer public access to the service prevent limit abuse.