### PR TITLE
Fix broken link to format specification on import page.

### DIFF
--- a/html/import.php
+++ b/html/import.php
@@ -55,7 +55,7 @@ require_once "../php/locale.php";
           <td style='vertical-align: top'><input type="radio" name="fileType" value="CSV"></td>
           <td><p><?php printf(
               _("<b>OpenFlights (.csv)</b> &mdash; Comma-separated value, exported from OpenFlights 'Export' or 'Backup') and easily edited or created in Excel or any other spreadsheet. See <%s>format specification</a>."),
-              'a href="#help" onClick="javascript:window.open("/help/csv.php", "CSV", "width=500, height=400,scrollbars=yes")"'
+              "a href='#help' onClick='window.open(\"/help/csv.php\", \"CSV\", \"width=500,height=400,scrollbars=yes\")'"
           ); ?></p>
           </td>
         </tr>


### PR DESCRIPTION
I noticed that trying to click on the "format specification" link on the import page did not work, and this is my attempt to fix it. Note that I have nearly 0 experience with PHP and only slightly more with javascript, but I *think* this should work. (I also unfortunately did not know how to test this).

Looking at the generated HTML page, you can see the link appears to be pretty broken:
```html
See <a href="#help" onClick="javascript:window.open(" help csv.php", "CSV", "width="500," height="400,scrollbars=yes&quot;)&quot;">format specification</a>
```

My fix is based on similar code in `html/settings.php` which does something similar and does seem to work. Namely I had to change most of the double quotes to single quotes and escape the double quotes used for arguments to window.open().

I'm cautiously optimistic that this would fix the issue here.