### PR TITLE
Updates to Fiji Airways and Nadi Airport

### DIFF
--- a/data/airlines.dat
+++ b/data/airlines.dat
@@ -877,7 +877,7 @@
 876,"Air Finland",\N,"OF","FIF","AIR FINLAND","Finland","Y"
 877,"Aerodata Flight Inspection",\N,"","FII","FLIGHT CHECKER","Germany","N"
 878,"Airfix Aviation",\N,"","FIX","AIRFIX","Finland","Y"
-879,"Air Pacific",\N,"FJ","FJI","PACIFIC","Fiji","Y"
+879,"Fiji Airways",\N,"FJ","FJI","FIJI","Fiji","Y"
 880,"Air Falcon",\N,"","FLD","","Pakistan","N"
 881,"Atlantic Airways",\N,"RC","FLI","FAROELINE","Faroe Islands","Y"
 882,"Air Florida",\N,"QH","FLZ","AIR FLORIDA","United States","Y"

--- a/data/airports.dat
+++ b/data/airports.dat
@@ -1892,7 +1892,7 @@
 1957,"Philip S. W. Goldson International Airport","Belize City","Belize","BZE","MZBZ",17.539100646972656,-88.30819702148438,15,-6,"U","America/Belize","airport","OurAirports"
 1958,"Aitutaki Airport","Aitutaki","Cook Islands","AIT","NCAI",-18.830900192260742,-159.76400756835938,14,-10,"U","Pacific/Rarotonga","airport","OurAirports"
 1959,"Rarotonga International Airport","Avarua","Cook Islands","RAR","NCRG",-21.2026996613,-159.805999756,19,-10,"U","Pacific/Rarotonga","airport","OurAirports"
-1960,"Nadi International Airport","Nandi","Fiji","NAN","NFFN",-17.755399703979492,177.4429931640625,59,12,"U","Pacific/Fiji","airport","OurAirports"
+1960,"Nadi International Airport","Nadi","Fiji","NAN","NFFN",-17.755399703979492,177.4429931640625,59,12,"U","Pacific/Fiji","airport","OurAirports"
 1961,"Nausori International Airport","Nausori","Fiji","SUV","NFNA",-18.04330062866211,178.5590057373047,17,12,"U","Pacific/Fiji","airport","OurAirports"
 1963,"Fua'amotu International Airport","Tongatapu","Tonga","TBU","NFTF",-21.241199493408203,-175.14999389648438,126,13,"U","Pacific/Tongatapu","airport","OurAirports"
 1964,"Vava'u International Airport","Vava'u","Tonga","VAV","NFTV",-18.58530044555664,-173.96200561523438,236,13,"U","Pacific/Tongatapu","airport","OurAirports"


### PR DESCRIPTION
1. Air Pacific was renamed to Fiji Airways in May 2012, and now uses the callsign FIJI
2. The airport in Nadi serves the region of Nadi, not Nandi. Nandi was only used by the Americans as the name of the airbase.

Sources: 
- https://en.wikipedia.org/wiki/Fiji_Airways
- https://en.wikipedia.org/wiki/Nadi_International_Airport