### PR TITLE
Сorrect city name for Minsk National Airport (MSQ)

### DIFF
--- a/data/airports-extended.dat
+++ b/data/airports-extended.dat
@@ -2809,7 +2809,7 @@
 2951,"Vitebsk Vostochny Airport","Vitebsk","Belarus","VTB","UMII",55.126499176025,30.349599838257,682,3,"E","Europe/Minsk","airport","OurAirports"
 2952,"Khrabrovo Airport","Kaliningrad","Russia","KGD","UMKK",54.88999938964844,20.592599868774414,42,2,"N","Europe/Kaliningrad","airport","OurAirports"
 2953,"Minsk 1 Airport","Minsk","Belarus","MHP","UMMM",53.864498138427734,27.53969955444336,748,3,"E","Europe/Minsk","airport","OurAirports"
-2954,"Minsk National Airport","Minsk 2","Belarus","MSQ","UMMS",53.882499694824,28.030700683594,670,3,"E","Europe/Minsk","airport","OurAirports"
+2954,"Minsk National Airport","Minsk","Belarus","MSQ","UMMS",53.882499694824,28.030700683594,670,3,"E","Europe/Minsk","airport","OurAirports"
 2955,"Abakan Airport","Abakan","Russia","ABA","UNAA",53.7400016784668,91.38500213623047,831,7,"N","Asia/Krasnoyarsk","airport","OurAirports"
 2956,"Barnaul Airport","Barnaul","Russia","BAX","UNBB",53.363800048828125,83.53849792480469,837,7,"N","Asia/Krasnoyarsk","airport","OurAirports"
 2957,"Kemerovo Airport","Kemorovo","Russia","KEJ","UNEE",55.27009963989258,86.1072006225586,863,7,"N","Asia/Krasnoyarsk","airport","OurAirports"

--- a/data/airports.dat
+++ b/data/airports.dat
@@ -2798,7 +2798,7 @@
 2951,"Vitebsk Vostochny Airport","Vitebsk","Belarus","VTB","UMII",55.126499176025,30.349599838257,682,3,"E","Europe/Minsk","airport","OurAirports"
 2952,"Khrabrovo Airport","Kaliningrad","Russia","KGD","UMKK",54.88999938964844,20.592599868774414,42,2,"N","Europe/Kaliningrad","airport","OurAirports"
 2953,"Minsk 1 Airport","Minsk","Belarus","MHP","UMMM",53.864498138427734,27.53969955444336,748,3,"E","Europe/Minsk","airport","OurAirports"
-2954,"Minsk National Airport","Minsk 2","Belarus","MSQ","UMMS",53.882499694824,28.030700683594,670,3,"E","Europe/Minsk","airport","OurAirports"
+2954,"Minsk National Airport","Minsk","Belarus","MSQ","UMMS",53.882499694824,28.030700683594,670,3,"E","Europe/Minsk","airport","OurAirports"
 2955,"Abakan Airport","Abakan","Russia","ABA","UNAA",53.7400016784668,91.38500213623047,831,7,"N","Asia/Krasnoyarsk","airport","OurAirports"
 2956,"Barnaul Airport","Barnaul","Russia","BAX","UNBB",53.363800048828125,83.53849792480469,837,7,"N","Asia/Krasnoyarsk","airport","OurAirports"
 2957,"Kemerovo Airport","Kemorovo","Russia","KEJ","UNEE",55.27009963989258,86.1072006225586,863,7,"N","Asia/Krasnoyarsk","airport","OurAirports"


### PR DESCRIPTION
The city field for [Minsk National Airport (MSQ)](https://en.wikipedia.org/wiki/Minsk_National_Airport) is listed as "Minsk 2" instead of the correct city name, "[Minsk](https://en.wikipedia.org/wiki/Minsk)".

This likely stems from the historical use of "Minsk 2" as the airport's name before it was officially renamed to "Minsk National Airport." But the designation refers to the airport itself, not the city.