### PR TITLE
Fix Skopje airport name to "Skopje International Airport"

### DIFF
--- a/data/airports-extended.dat
+++ b/data/airports-extended.dat
@@ -1687,7 +1687,7 @@
 1734,"Bălți International Airport","Saltsy","Moldova","BZY","LUBL",47.843056,27.777222,758,2,"E","Europe/Chisinau","airport","OurAirports"
 1735,"Chişinău International Airport","Chisinau","Moldova","KIV","LUKK",46.92770004272461,28.930999755859375,399,2,"E","Europe/Chisinau","airport","OurAirports"
 1736,"Ohrid St. Paul the Apostle Airport","Ohrid","Macedonia","OHD","LWOH",41.18,20.7423,2313,1,"E","Europe/Skopje","airport","OurAirports"
-1737,"Skopje Alexander the Great Airport","Skopje","Macedonia","SKP","LWSK",41.961601,21.621401,781,1,"E","Europe/Skopje","airport","OurAirports"
+1737,"Skopje International Airport","Skopje","Macedonia","SKP","LWSK",41.961601,21.621401,781,1,"E","Europe/Skopje","airport","OurAirports"
 1738,"Gibraltar Airport","Gibraltar","Gibraltar","GIB","LXGB",36.1511993408,-5.3496599197400005,15,1,"N","Europe/Gibraltar","airport","OurAirports"
 1739,"Belgrade Nikola Tesla Airport","Belgrade","Serbia","BEG","LYBE",44.8184013367,20.3090991974,335,1,"E","Europe/Belgrade","airport","OurAirports"
 1740,"Nis Airport","Nis","Serbia","INI","LYNI",43.337299,21.853701,648,1,"E","Europe/Belgrade","airport","OurAirports"

--- a/data/airports.dat
+++ b/data/airports.dat
@@ -1681,7 +1681,7 @@
 1734,"Bălți International Airport","Saltsy","Moldova","BZY","LUBL",47.843056,27.777222,758,2,"E","Europe/Chisinau","airport","OurAirports"
 1735,"Chişinău International Airport","Chisinau","Moldova","KIV","LUKK",46.92770004272461,28.930999755859375,399,2,"E","Europe/Chisinau","airport","OurAirports"
 1736,"Ohrid St. Paul the Apostle Airport","Ohrid","Macedonia","OHD","LWOH",41.18,20.7423,2313,1,"E","Europe/Skopje","airport","OurAirports"
-1737,"Skopje Alexander the Great Airport","Skopje","Macedonia","SKP","LWSK",41.961601,21.621401,781,1,"E","Europe/Skopje","airport","OurAirports"
+1737,"Skopje International Airport","Skopje","Macedonia","SKP","LWSK",41.961601,21.621401,781,1,"E","Europe/Skopje","airport","OurAirports"
 1738,"Gibraltar Airport","Gibraltar","Gibraltar","GIB","LXGB",36.1511993408,-5.3496599197400005,15,1,"N","Europe/Gibraltar","airport","OurAirports"
 1739,"Belgrade Nikola Tesla Airport","Belgrade","Serbia","BEG","LYBE",44.8184013367,20.3090991974,335,1,"E","Europe/Belgrade","airport","OurAirports"
 1740,"Nis Airport","Nis","Serbia","INI","LYNI",43.337299,21.853701,648,1,"E","Europe/Belgrade","airport","OurAirports"


### PR DESCRIPTION
## Summary
Updates the Skopje airport name from "Skopje Alexander the Great Airport" to "Skopje International Airport" to reflect the current official name.

## Changes
- Updated airport name in `data/airports.dat`
- Updated airport name in `data/airports-extended.dat`

## Airport Details
- IATA: SKP
- ICAO: LWSK
- Country: Macedonia