### PR TITLE
apsearch: keep dafif and oa tables in the identifier-splice allowlist

### DIFF
--- a/php/apsearch.php
+++ b/php/apsearch.php
@@ -373,7 +373,7 @@ TXT;
     exit;
 }
 
-if ($tableName != "airports" || $tableName != "airports_dafif" || $tableName != "airports_oa") {
+if ($tableName != "airports" && $tableName != "airports_dafif" && $tableName != "airports_oa") {
     $tableName = "airports";
 }
 


### PR DESCRIPTION
apsearch.php builds a hard-coded `$tables` array used as an allowlist before
splicing a user-supplied identifier into a SQL query. The previous list omitt